### PR TITLE
fix(notification): display game time and period in Discord notifications

### DIFF
--- a/watchgameupdates/internal/handlers/watchgameupdates_handler.go
+++ b/watchgameupdates/internal/handlers/watchgameupdates_handler.go
@@ -61,23 +61,7 @@ func WatchGameUpdatesHandler(
 		gameData, err := fetcher.FetchAndParseGameData(payload.Game.ID, requiredKeys)
 
 		// Populate game state (period/time) from play-by-play data
-		if lastPlay.TypeDescKey == "game-end" {
-			gameData["gameState"] = "Final"
-		} else if lastPlay.TimeRemaining != "" {
-			switch lastPlay.PeriodDescriptor.PeriodType {
-			case "OT":
-				gameData["gameState"] = fmt.Sprintf("%s left, OT", lastPlay.TimeRemaining)
-			case "SO":
-				gameData["gameState"] = "Shootout"
-			default:
-				periodSuffix := map[int]string{1: "1st", 2: "2nd", 3: "3rd"}
-				suffix, ok := periodSuffix[lastPlay.Period]
-				if !ok {
-					suffix = fmt.Sprintf("%dth", lastPlay.Period)
-				}
-				gameData["gameState"] = fmt.Sprintf("%s left, %s period", lastPlay.TimeRemaining, suffix)
-			}
-		}
+		gameData["gameState"] = formatGameState(lastPlay)
 
 		if lastPlay.TypeDescKey == "game-end" {
 			homeGoals, homeGOK := gameData["homeTeamGoals"]
@@ -223,4 +207,31 @@ func scheduleNextCheck(payload models.Payload) error {
 
 	log.Printf("Successfully scheduled next check task for game %s at %v", payload.Game.ID, scheduleTime.AsTime().Format(time.RFC3339))
 	return nil
+}
+
+// formatGameState returns a formatted game state string based on the play data.
+// Returns "Final" for game-end, "Shootout" for SO, "X:XX left, OT" for overtime,
+// or "X:XX left, Nth period" for regular periods.
+func formatGameState(play models.Play) string {
+	if play.TypeDescKey == "game-end" {
+		return "Final"
+	}
+
+	if play.TimeRemaining == "" {
+		return ""
+	}
+
+	switch play.PeriodDescriptor.PeriodType {
+	case "OT":
+		return fmt.Sprintf("%s left, OT", play.TimeRemaining)
+	case "SO":
+		return "Shootout"
+	default:
+		periodSuffix := map[int]string{1: "1st", 2: "2nd", 3: "3rd"}
+		suffix, ok := periodSuffix[play.PeriodDescriptor.Number]
+		if !ok {
+			suffix = fmt.Sprintf("%dth", play.PeriodDescriptor.Number)
+		}
+		return fmt.Sprintf("%s left, %s period", play.TimeRemaining, suffix)
+	}
 }

--- a/watchgameupdates/internal/handlers/watchgameupdates_handler_test.go
+++ b/watchgameupdates/internal/handlers/watchgameupdates_handler_test.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"testing"
+
+	"watchgameupdates/internal/models"
 )
 
 type adjustScoreTestCase struct {
@@ -200,4 +202,132 @@ func buildGameData(tc adjustScoreTestCase) map[string]string {
 	}
 
 	return data
+}
+
+func TestFormatGameState(t *testing.T) {
+	testCases := []struct {
+		name     string
+		play     models.Play
+		expected string
+	}{
+		{
+			name: "GameEnd_ReturnsFinal",
+			play: models.Play{
+				TypeDescKey:   "game-end",
+				TimeRemaining: "00:00",
+				PeriodDescriptor: models.PeriodDescriptor{
+					Number:     3,
+					PeriodType: "REG",
+				},
+			},
+			expected: "Final",
+		},
+		{
+			name: "FirstPeriod_ReturnsCorrectSuffix",
+			play: models.Play{
+				TypeDescKey:   "shot-on-goal",
+				TimeRemaining: "15:32",
+				PeriodDescriptor: models.PeriodDescriptor{
+					Number:     1,
+					PeriodType: "REG",
+				},
+			},
+			expected: "15:32 left, 1st period",
+		},
+		{
+			name: "SecondPeriod_ReturnsCorrectSuffix",
+			play: models.Play{
+				TypeDescKey:   "goal",
+				TimeRemaining: "06:56",
+				PeriodDescriptor: models.PeriodDescriptor{
+					Number:     2,
+					PeriodType: "REG",
+				},
+			},
+			expected: "06:56 left, 2nd period",
+		},
+		{
+			name: "ThirdPeriod_ReturnsCorrectSuffix",
+			play: models.Play{
+				TypeDescKey:   "missed-shot",
+				TimeRemaining: "01:45",
+				PeriodDescriptor: models.PeriodDescriptor{
+					Number:     3,
+					PeriodType: "REG",
+				},
+			},
+			expected: "01:45 left, 3rd period",
+		},
+		{
+			name: "FourthPeriod_ReturnsFallbackSuffix",
+			play: models.Play{
+				TypeDescKey:   "blocked-shot",
+				TimeRemaining: "10:00",
+				PeriodDescriptor: models.PeriodDescriptor{
+					Number:     4,
+					PeriodType: "REG",
+				},
+			},
+			expected: "10:00 left, 4th period",
+		},
+		{
+			name: "Overtime_ReturnsOTFormat",
+			play: models.Play{
+				TypeDescKey:   "shot-on-goal",
+				TimeRemaining: "03:22",
+				PeriodDescriptor: models.PeriodDescriptor{
+					Number:     4,
+					PeriodType: "OT",
+				},
+			},
+			expected: "03:22 left, OT",
+		},
+		{
+			name: "Shootout_ReturnsShootout",
+			play: models.Play{
+				TypeDescKey:   "goal",
+				TimeRemaining: "00:00",
+				PeriodDescriptor: models.PeriodDescriptor{
+					Number:     5,
+					PeriodType: "SO",
+				},
+			},
+			expected: "Shootout",
+		},
+		{
+			name: "EmptyTimeRemaining_ReturnsEmptyString",
+			play: models.Play{
+				TypeDescKey:   "period-start",
+				TimeRemaining: "",
+				PeriodDescriptor: models.PeriodDescriptor{
+					Number:     1,
+					PeriodType: "REG",
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "PeriodDescriptorNumber_UsedInsteadOfPeriodField",
+			play: models.Play{
+				TypeDescKey:   "shot-on-goal",
+				TimeRemaining: "12:00",
+				Period:        0, // This field is not populated by NHL API
+				PeriodDescriptor: models.PeriodDescriptor{
+					Number:     2, // This is what the NHL API populates
+					PeriodType: "REG",
+				},
+			},
+			expected: "12:00 left, 2nd period",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := formatGameState(tc.play)
+
+			if result != tc.expected {
+				t.Errorf("Expected '%s', got '%s'", tc.expected, result)
+			}
+		})
+	}
 }

--- a/watchgameupdates/internal/notification/discord.go
+++ b/watchgameupdates/internal/notification/discord.go
@@ -40,6 +40,7 @@ func NewDiscordNotifier(config NotifierConfig) (*DiscordNotifier, error) {
 		"awayTeamGoals",
 		"homeTeamShootOutGoals",
 		"awayTeamShootOutGoals",
+		"gameState",
 	}
 
 	return &DiscordNotifier{


### PR DESCRIPTION
## Summary
Fixes missing game state information in Discord notifications. Notifications now include period and time remaining (e.g., "6:56 left, 2nd period") instead of showing only score and xG stats.

## Problem
The NHL API populates `periodDescriptor.number` but the code was incorrectly reading from the top-level `period` field (which is always 0). This caused notifications to either:
- Show "0:00 left, 0th period" 
- Not show game state at all

Example JSON from NHL API:
```json
{
  "periodDescriptor": {
    "number": 2,
    "periodType": "REG"
  },
  "timeRemaining": "06:56"
}
```

## Changes

### 1. Fixed game state formatting ([watchgameupdates_handler.go](watchgameupdates/internal/handlers/watchgameupdates_handler.go))
- Extracted game state logic into testable `formatGameState()` function
- Changed from `lastPlay.Period` → `lastPlay.PeriodDescriptor.Number`
- Supports all period types: Regular (1st, 2nd, 3rd), OT, Shootout, Final

### 2. Added gameState to required data keys ([discord.go](watchgameupdates/internal/notification/discord.go))
- Added `"gameState"` to Discord notifier's `requiredDataKeys`
- Ensures game state is passed through notification pipeline

### 3. Comprehensive test coverage ([watchgameupdates_handler_test.go](watchgameupdates/internal/handlers/watchgameupdates_handler_test.go))
Added 9 test cases covering:
- ✓ All period suffixes (1st, 2nd, 3rd, 4th+)
- ✓ Overtime format ("X:XX left, OT")
- ✓ Shootout format ("Shootout")
- ✓ Game end format ("Final")
- ✓ Empty time handling
- ✓ **Bug fix verification** - uses PeriodDescriptor.Number when Period=0

## Notification Format

**Before:**
```
Maple Leafs 3 - 2 Canadiens
• Maple Leafs: 2.50 xG
• Canadiens: 2.50 xG
```

**After:**
```
Maple Leafs 3 - 2 Canadiens
• 6:56 left, 2nd period
• Maple Leafs: 2.50 xG
• Canadiens: 2.50 xG
```

## Test Results
All tests passing ✓
```bash
=== RUN   TestFormatGameState
--- PASS: TestFormatGameState (0.00s)
    --- PASS: TestFormatGameState/SecondPeriod_ReturnsCorrectSuffix (0.00s)
    --- PASS: TestFormatGameState/Overtime_ReturnsOTFormat (0.00s)
    --- PASS: TestFormatGameState/Shootout_ReturnsShootout (0.00s)
    --- PASS: TestFormatGameState/PeriodDescriptorNumber_UsedInsteadOfPeriodField (0.00s)
```

Integration test verified with mock API showing correct game states throughout game progression.

## Related
- Depends on FirepowerApp/gameDataEmulator#6 for updated mock API tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)