### PR TITLE
feat(makefile): add schedule-team target for single-team scheduling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,9 @@
 #   make logs      - Follow logs from running containers
 #   make schedule  - Start full system and run scheduler with live NHL data
 #   make schedule-test - Start full system and run scheduler with test data
+#   make schedule-team TEAM=TRI - Run scheduler for a single team against an already-running emulator
 
-.PHONY: help live emulator stop logs schedule schedule-test
+.PHONY: help live emulator stop logs schedule schedule-test schedule-team
 
 BLUE  := \033[0;34m
 GREEN := \033[0;32m
@@ -50,6 +51,12 @@ schedule: ## Start full system and run scheduler with live NHL data
 	@printf "  Backend:        http://localhost:8080\n"
 	@printf "  Tasks emulator: http://localhost:8123\n"
 	@printf "View logs: make logs  |  Stop: make stop\n"
+
+schedule-team: ## Run scheduler for one team against running emulator (usage: make schedule-team TEAM=TOR)
+	@if [ -z "$(TEAM)" ]; then printf "Error: TEAM is required. Usage: make schedule-team TEAM=TOR\n"; exit 1; fi
+	@printf "$(BLUE)[INFO]$(NC) Running scheduler for team $(TEAM)...\n"
+	@docker compose -f docker-compose.yml -f docker-compose.live.yml run --rm -e TEAM_FILTER=$(TEAM) scheduler
+	@printf "$(GREEN)[OK]$(NC) Scheduler finished for $(TEAM)\n"
 
 schedule-test: ## Start full system and run scheduler with test data
 	@printf "$(BLUE)[INFO]$(NC) Pulling game data emulator...\n"


### PR DESCRIPTION
## Summary
- Adds `make schedule-team TEAM=TRI`, which runs the scheduler one-shot against the already-running backend and Cloud Tasks emulator.
- Sets `TEAM_FILTER` (already honored by the scheduler) so only games involving the supplied tricode get scheduled.
- Errors out clearly if `TEAM` is missing. Uses `docker-compose.live.yml`, so it inherits the same `.env.home` config as `make live` / `make schedule`.

Enables a workflow of \`make live\` once, then repeated \`make schedule-team TEAM=...\` invocations to manually schedule specific teams.

## Test plan
- [ ] \`make live\` to bring up backend + tasks emulator
- [ ] \`make schedule-team\` (no TEAM) prints the usage error and exits non-zero
- [ ] \`make schedule-team TEAM=TOR\` runs scheduler, filters to TOR games, exits cleanly
- [ ] Re-running with a different TEAM works without conflicting with the prior run
- [ ] \`make stop\` cleans up

🤖 Generated with [Claude Code](https://claude.com/claude-code)