### PR TITLE
feat(logging): add structured slog logging and Grafana Loki integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ make watch TEAM=COL    # E2E live test: schedule today's game and follow logs
 | `notification/` | Discord and LiveActivity (APNs broadcast push) notifiers |
 | `notification/liveactivity/` | iOS Live Activity APNs push (JWT signing, formatter, channel map) |
 | `config/` | Environment configuration |
+| `logger/` | Shared `slog.Logger` factory (JSON/text output, log level from env) |
 
 **Service ports:**
 
@@ -102,6 +103,9 @@ make watch TEAM=COL    # E2E live test: schedule today's game and follow logs
 | Cloud Tasks Emulator | 8123 |
 | Mock MoneyPuck API | 8124 |
 | Mock NHL API | 8125 |
+| Grafana Alloy UI (when using grafana/loki targets) | 12345 |
+| Local Loki API (when using loki-* targets) | 3100 |
+| Local Grafana UI (when using loki-* targets) | 3000 |
 
 ## Environment Variables
 
@@ -119,6 +123,10 @@ DISCORD_CHANNEL_ID=          # Discord channel to post game updates
 MESSAGE_INTERVAL_SECONDS=60       # active-play polling interval (default 60)
 PERIOD_END_INTERVAL_SECONDS=1200  # post-period-end wait before next poll (default 1200)
 
+# Logging (consumed by the Go app via internal/logger)
+LOG_FORMAT=json              # "json" (default) or "text" for human-readable output
+LOG_LEVEL=info               # "debug", "info" (default), "warn", "error"
+
 # Live Activity APNs (optional — set LIVEACTIVITY_PUSH_ENABLED=true to enable)
 LIVEACTIVITY_PUSH_ENABLED=
 APNS_TEAM_ID=                # 10-char Apple Developer Team ID
@@ -126,6 +134,12 @@ APNS_KEY_ID=                 # .p8 key ID from App Store Connect
 APNS_AUTH_KEY=               # base64-encoded .p8 file contents
 APNS_TOPIC=                  # bundle ID, e.g. me.blakenelson.firepower
 APNS_HOST=                   # api.sandbox.push.apple.com or api.push.apple.com
+
+# Grafana Cloud Loki (consumed by Grafana Alloy sidecar, not the Go app)
+# See docs/grafana-loki-setup.md for setup instructions.
+GRAFANA_LOKI_URL=            # e.g. https://logs-prod-006.grafana.net/loki/api/v1/push
+GRAFANA_LOKI_USER=           # Grafana Cloud numeric instance ID
+GRAFANA_LOKI_API_KEY=        # API key with "Logs Writer" role
 ```
 
 ## Commit Guidelines

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,15 @@
 
 TEAM ?= COL
 
-.PHONY: help live emulator stop logs schedule schedule-test watch schedule-team redis-up redis-test redis-schedule redis-schedule-test redis-schedule-team redis-stop redis-logs build-enqueue
+# Log format for all container services.
+# "json" (default) is best for Grafana/Loki. "text" is human-readable for local dev.
+# Usage: make emulator LOG_FORMAT=text
+LOG_FORMAT ?= json
+LOG_LEVEL  ?= info
+export LOG_FORMAT
+export LOG_LEVEL
+
+.PHONY: help live emulator stop logs schedule schedule-test watch schedule-team schedule-fake-team redis-up redis-test redis-schedule redis-schedule-test redis-schedule-team redis-schedule-fake-team redis-stop redis-logs build-enqueue grafana-live grafana-emulator grafana-redis grafana-redis-test loki-live loki-emulator
 
 BLUE  := \033[0;34m
 GREEN := \033[0;32m
@@ -164,3 +172,95 @@ build-enqueue: ## Build the Redis queue enqueue CLI tool
 	@printf "$(BLUE)[INFO]$(NC) Building enqueue CLI tool...\n"
 	@go run build.go -target enqueue
 	@printf "$(GREEN)[OK]$(NC) Enqueue CLI built: ./bin/enqueue\n"
+
+schedule-fake-team: ## Run scheduler for one team using a fake local schedule file (usage: make schedule-fake-team TEAM=TOR [DATE=YYYY-MM-DD])
+	@if [ -z "$(TEAM)" ]; then printf "Error: TEAM is required. Usage: make schedule-fake-team TEAM=TOR\n"; exit 1; fi
+	@printf "$(BLUE)[INFO]$(NC) Running scheduler for team $(TEAM) using fake schedule...\n"
+	@podman-compose -f docker-compose.yml -f docker-compose.emulator.yml run --rm \
+	  -e TEAM_FILTER=$(TEAM) \
+	  -e SCHEDULE_FILE=/testdata/schedule.json \
+	  -e INCLUDE_LIVE_GAMES=true \
+	  $(if $(DATE),-e SCHEDULE_DATE=$(DATE),) \
+	  scheduler
+	@printf "$(GREEN)[OK]$(NC) Scheduler finished for $(TEAM)\n"
+
+redis-schedule-fake-team: ## Run Redis scheduler for one team using a fake local schedule file (usage: make redis-schedule-fake-team TEAM=TOR [DATE=YYYY-MM-DD])
+	@if [ -z "$(TEAM)" ]; then printf "Error: TEAM is required. Usage: make redis-schedule-fake-team TEAM=TOR\n"; exit 1; fi
+	@printf "$(BLUE)[INFO]$(NC) Running Redis scheduler for team $(TEAM) using fake schedule...\n"
+	@podman-compose -f $(COMPOSE_REDIS) run --rm \
+	  -e TEAM_FILTER=$(TEAM) \
+	  -e SCHEDULE_FILE=/testdata/schedule.json \
+	  -e INCLUDE_LIVE_GAMES=true \
+	  $(if $(DATE),-e SCHEDULE_DATE=$(DATE),) \
+	  scheduler
+	@printf "$(GREEN)[OK]$(NC) Redis scheduler finished for $(TEAM)\n"
+
+##@ Grafana Cloud Log Shipping (requires GRAFANA_LOKI_URL, GRAFANA_LOKI_USER, GRAFANA_LOKI_API_KEY)
+
+grafana-live: ## Start live stack + Grafana Alloy log shipping
+	@podman-compose -f docker-compose.yml -f docker-compose.live.yml -f docker-compose.grafana.yml \
+	  --profile grafana up --build -d
+	@printf "$(GREEN)[OK]$(NC) Started with Grafana Alloy\n"
+	@printf "  Backend:        http://localhost:8080\n"
+	@printf "  Tasks emulator: http://localhost:8123\n"
+	@printf "  Alloy UI:       http://localhost:12345\n"
+	@printf "View logs: make logs  |  Stop: make stop\n"
+
+grafana-emulator: ## Start mock API stack + Grafana Alloy log shipping
+	@printf "$(BLUE)[INFO]$(NC) Pulling game data emulator...\n"
+	@podman pull docker.io/blnelson/firepowermockdataserver:latest
+	@podman-compose -f docker-compose.yml -f docker-compose.emulator.yml -f docker-compose.grafana.yml \
+	  --profile grafana up --build -d
+	@printf "$(GREEN)[OK]$(NC) Started with Grafana Alloy\n"
+	@printf "  Backend:            http://localhost:8080\n"
+	@printf "  Tasks emulator:     http://localhost:8123\n"
+	@printf "  Game data emulator: http://localhost:8125 (NHL), http://localhost:8124 (MoneyPuck)\n"
+	@printf "  Alloy UI:           http://localhost:12345\n"
+	@printf "View logs: make logs  |  Stop: make stop\n"
+
+grafana-redis: ## Start Redis worker stack + Grafana Alloy log shipping (live APIs)
+	@podman-compose -f $(COMPOSE_REDIS) -f docker-compose.grafana.yml \
+	  --profile home --profile grafana up --build -d
+	@printf "$(GREEN)[OK]$(NC) Started Redis worker with Grafana Alloy\n"
+	@printf "  Asynqmon dashboard: http://localhost:8980\n"
+	@printf "  Redis:              localhost:6379\n"
+	@printf "  Alloy UI:           http://localhost:12345\n"
+	@printf "View logs: make redis-logs  |  Stop: make redis-stop\n"
+
+grafana-redis-test: ## Start Redis worker stack + Grafana Alloy log shipping (mock APIs)
+	@printf "$(BLUE)[INFO]$(NC) Pulling game data emulator...\n"
+	@podman pull docker.io/blnelson/firepowermockdataserver:latest
+	@podman-compose -f $(COMPOSE_REDIS) -f docker-compose.grafana.yml \
+	  --profile test --profile grafana up --build -d
+	@printf "$(GREEN)[OK]$(NC) Started Redis test environment with Grafana Alloy\n"
+	@printf "  Asynqmon dashboard:  http://localhost:8980\n"
+	@printf "  Redis:               localhost:6379\n"
+	@printf "  Mock NHL API:        http://localhost:8125\n"
+	@printf "  Mock MoneyPuck API:  http://localhost:8124\n"
+	@printf "  Alloy UI:            http://localhost:12345\n"
+	@printf "View logs: make redis-logs  |  Stop: make redis-stop\n"
+
+##@ Local Loki Stack (no Grafana Cloud account needed)
+
+loki-live: ## Start live stack + local Loki + Grafana UI for log testing
+	@podman-compose -f docker-compose.yml -f docker-compose.live.yml -f docker-compose.loki-local.yml \
+	  up --build -d
+	@printf "$(GREEN)[OK]$(NC) Started with local Loki stack\n"
+	@printf "  Backend:        http://localhost:8080\n"
+	@printf "  Tasks emulator: http://localhost:8123\n"
+	@printf "  Grafana UI:     http://localhost:3000  (Explore → Loki → {service=\"backend\"})\n"
+	@printf "  Alloy UI:       http://localhost:12345\n"
+	@printf "View logs: make logs  |  Stop: make stop\n"
+
+loki-emulator: ## Start mock API stack + local Loki + Grafana UI for log testing
+	@printf "$(BLUE)[INFO]$(NC) Pulling game data emulator...\n"
+	@podman pull docker.io/blnelson/firepowermockdataserver:latest
+	@podman-compose -f docker-compose.yml -f docker-compose.emulator.yml -f docker-compose.loki-local.yml \
+	  up --build -d
+	@printf "$(GREEN)[OK]$(NC) Started with local Loki stack\n"
+	@printf "  Backend:            http://localhost:8080\n"
+	@printf "  Tasks emulator:     http://localhost:8123\n"
+	@printf "  Game data emulator: http://localhost:8125 (NHL), http://localhost:8124 (MoneyPuck)\n"
+	@printf "  Grafana UI:         http://localhost:3000  (Explore → Loki → {service=\"backend\"})\n"
+	@printf "  Alloy UI:           http://localhost:12345\n"
+	@printf "View logs: make logs  |  Stop: make stop\n"

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ make logs                    # Follow logs from running containers
 make schedule                # Start full system and run scheduler with live NHL data
 make schedule-test           # Start full system and run scheduler with mock data
 make schedule-team TEAM=TOR [DATE=YYYY-MM-DD]  # Run scheduler for one team
+make schedule-fake-team TEAM=TOR [DATE=YYYY-MM-DD]  # Run scheduler for one team using local fake schedule
 make watch TEAM=COL          # Live e2e test: schedule today's real game and tail logs
 
 # Redis mode
@@ -107,9 +108,25 @@ make redis-test              # Start Redis test environment (with mock APIs)
 make redis-schedule          # Start Redis environment and run scheduler with live data
 make redis-schedule-test     # Start Redis environment and run scheduler with mock data
 make redis-schedule-team TEAM=TOR [DATE=YYYY-MM-DD]  # Run Redis scheduler for one team
+make redis-schedule-fake-team TEAM=TOR [DATE=YYYY-MM-DD]  # Run Redis scheduler using local fake schedule
 make redis-stop              # Stop Redis containers
 make redis-logs              # View Redis worker logs
 make build-enqueue           # Build the Redis enqueue CLI tool
+
+# Log format control (applies to any target)
+make emulator LOG_FORMAT=text        # Human-readable structured logs (local dev)
+make emulator LOG_FORMAT=json        # JSON logs (default, best for Grafana)
+make live LOG_FORMAT=text            # Live APIs with text logs
+
+# Local Loki stack (no Grafana Cloud account needed — for testing log pipeline)
+make loki-emulator           # Mock APIs + local Loki + Grafana UI
+make loki-live               # Live APIs + local Loki + Grafana UI
+
+# Grafana Cloud log shipping (set GRAFANA_LOKI_URL, GRAFANA_LOKI_USER, GRAFANA_LOKI_API_KEY)
+make grafana-emulator        # Cloud Tasks + mock APIs + Alloy → Grafana Cloud
+make grafana-live            # Cloud Tasks + live APIs + Alloy → Grafana Cloud
+make grafana-redis-test      # Redis + mock APIs + Alloy → Grafana Cloud
+make grafana-redis           # Redis + live APIs + Alloy → Grafana Cloud
 ```
 
 ### Environment Modes
@@ -193,6 +210,33 @@ The `--mode` flag on the binary controls which backend is used:
 
 See [docs/queue-visualization.md](docs/queue-visualization.md) for details on using the Asynqmon dashboard.
 
+### Log Format
+
+All services emit structured logs to stdout. The format is controlled by two environment variables:
+
+| Variable | Values | Default | Description |
+|---|---|---|---|
+| `LOG_FORMAT` | `json`, `text` | `json` | `json` produces machine-readable output (best for Grafana/Loki). `text` produces human-readable key=value output for local dev. |
+| `LOG_LEVEL` | `debug`, `info`, `warn`, `error` | `info` | Minimum log level to emit. Use `debug` to see play-by-play fetch details. |
+
+Pass these as Makefile variables on any target:
+
+```bash
+make emulator LOG_FORMAT=text            # human-readable
+make live LOG_FORMAT=json LOG_LEVEL=debug  # JSON with debug output
+make schedule-test LOG_FORMAT=text       # full stack with readable logs
+```
+
+JSON log lines look like:
+```json
+{"time":"2026-05-26T14:30:00Z","level":"INFO","msg":"game update processed","game_id":"2024030411","last_play_type":"goal","should_reschedule":true}
+```
+
+Text log lines look like:
+```
+time=2026-05-26T14:30:00Z level=INFO msg="game update processed" game_id=2024030411 last_play_type=goal should_reschedule=true
+```
+
 ### Configuration
 
 Environment files are located in `watchgameupdates/`:
@@ -248,9 +292,17 @@ The scheduler commands have equivalents for both queue backends:
 
 | Cloud Tasks | Redis | Description |
 |---|---|---|
-| `make schedule` | `make redis-schedule` | Run scheduler with live NHL data |
-| `make schedule-test` | `make redis-schedule-test` | Run scheduler with mock data |
-| `make schedule-team TEAM=TOR` | `make redis-schedule-team TEAM=TOR` | Run scheduler for one team |
+| `make schedule` | `make redis-schedule` | Full stack + scheduler, live NHL data |
+| `make schedule-test` | `make redis-schedule-test` | Full stack + scheduler, mock data |
+| `make schedule-team TEAM=TOR` | `make redis-schedule-team TEAM=TOR` | Scheduler only, one team, real NHL schedule |
+| `make schedule-fake-team TEAM=TOR` | `make redis-schedule-fake-team TEAM=TOR` | Scheduler only, one team, local fake schedule |
+
+All targets accept `LOG_FORMAT=text` or `LOG_FORMAT=json` (default):
+
+```bash
+make schedule-test LOG_FORMAT=text       # readable logs during full stack test
+make schedule-team TEAM=TOR LOG_FORMAT=json  # JSON logs for Loki ingestion
+```
 
 **Cloud Tasks (default):**
 
@@ -390,6 +442,42 @@ Worker Mode:     Redis  → Asynq Handler → GameProcessor → Reschedule via R
 ```
 
 ## Advanced Usage
+
+### Grafana Loki Log Shipping
+
+The backend ships logs to Grafana Loki via [Grafana Alloy](https://grafana.com/docs/alloy/), a sidecar container that reads Docker container stdout and forwards it to Loki. The Go application writes only to stdout (12-factor compliant) and is unaware of the destination.
+
+**Testing locally (no account needed):**
+
+```bash
+make loki-emulator   # or: make loki-live
+```
+
+This starts a local Loki + Grafana UI stack. Open http://localhost:3000, go to **Explore → Loki**, and query `{service="backend"}`. See [docs/grafana-loki-setup.md](docs/grafana-loki-setup.md) for full instructions.
+
+**Shipping to Grafana Cloud:**
+
+1. Set credentials in `.env.home`:
+   ```
+   GRAFANA_LOKI_URL=https://logs-prod-XXX.grafana.net/loki/api/v1/push
+   GRAFANA_LOKI_USER=<instance ID>
+   GRAFANA_LOKI_API_KEY=<Logs Writer API key>
+   ```
+2. Run:
+   ```bash
+   make grafana-live        # Cloud Tasks mode
+   make grafana-redis       # Redis worker mode
+   ```
+3. Verify: Alloy pipeline UI at http://localhost:12345, then query logs in Grafana Cloud.
+
+Example LogQL queries once logs are flowing:
+```logql
+{service="backend"} | json | level="ERROR"
+{service="backend"} | json | game_id="2024030411"
+{service="scheduler"} | json | msg="scheduling complete"
+```
+
+See [docs/grafana-loki-setup.md](docs/grafana-loki-setup.md) for the complete setup guide including credential rotation and troubleshooting.
 
 ### Direct Compose Usage
 

--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -1,0 +1,51 @@
+// Grafana Alloy configuration — ships container logs to Grafana Cloud Loki.
+//
+// Credentials are read from environment variables (never hardcoded):
+//   GRAFANA_LOKI_URL      e.g. https://logs-prod-006.grafana.net/loki/api/v1/push
+//   GRAFANA_LOKI_USER     Grafana Cloud numeric instance ID
+//   GRAFANA_LOKI_API_KEY  API key with "Logs Writer" role
+//
+// For local testing without Grafana Cloud, use docker-compose.loki-local.yml
+// which sets GRAFANA_LOKI_URL=http://loki:3100/loki/api/v1/push with no auth.
+
+discovery.docker "containers" {
+  host = "unix:///var/run/docker.sock"
+}
+
+loki.relabel "containers" {
+  forward_to = []
+
+  rule {
+    source_labels = ["__meta_docker_container_label_com_docker_compose_service"]
+    target_label  = "service"
+  }
+
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = "/(.*)"
+    target_label  = "container"
+  }
+
+  rule {
+    source_labels = ["__meta_docker_container_label_com_docker_compose_project"]
+    target_label  = "compose_project"
+  }
+}
+
+loki.source.docker "containers" {
+  host          = "unix:///var/run/docker.sock"
+  targets       = discovery.docker.containers.targets
+  forward_to    = [loki.write.destination.receiver]
+  relabel_rules = loki.relabel.containers.rules
+}
+
+loki.write "destination" {
+  endpoint {
+    url = env("GRAFANA_LOKI_URL")
+
+    basic_auth {
+      username = env("GRAFANA_LOKI_USER")
+      password = env("GRAFANA_LOKI_API_KEY")
+    }
+  }
+}

--- a/alloy/config.loki-local.alloy
+++ b/alloy/config.loki-local.alloy
@@ -1,0 +1,40 @@
+// Grafana Alloy configuration for local Loki testing.
+// Ships container logs to a local Loki instance — no Grafana Cloud credentials needed.
+// Use with docker-compose.loki-local.yml.
+
+discovery.docker "containers" {
+  host = "unix:///var/run/docker.sock"
+}
+
+loki.relabel "containers" {
+  forward_to = []
+
+  rule {
+    source_labels = ["__meta_docker_container_label_com_docker_compose_service"]
+    target_label  = "service"
+  }
+
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = "/(.*)"
+    target_label  = "container"
+  }
+
+  rule {
+    source_labels = ["__meta_docker_container_label_com_docker_compose_project"]
+    target_label  = "compose_project"
+  }
+}
+
+loki.source.docker "containers" {
+  host          = "unix:///var/run/docker.sock"
+  targets       = discovery.docker.containers.targets
+  forward_to    = [loki.write.local.receiver]
+  relabel_rules = loki.relabel.containers.rules
+}
+
+loki.write "local" {
+  endpoint {
+    url = "http://loki:3100/loki/api/v1/push"
+  }
+}

--- a/docker-compose.grafana.yml
+++ b/docker-compose.grafana.yml
@@ -1,0 +1,33 @@
+# Grafana Alloy overlay — ships container logs to Grafana Cloud Loki.
+#
+# Activate by stacking this file on top of your base compose file:
+#   make grafana-live        # Live APIs + Alloy
+#   make grafana-emulator    # Mock APIs + Alloy
+#   make grafana-redis       # Redis worker + Alloy
+#   make grafana-redis-test  # Redis worker + mock APIs + Alloy
+#
+# Required environment variables (set in .env.home or export in your shell):
+#   GRAFANA_LOKI_URL     = https://logs-prod-XXX.grafana.net/loki/api/v1/push
+#   GRAFANA_LOKI_USER    = <numeric instance ID>
+#   GRAFANA_LOKI_API_KEY = <API key with Logs Writer role>
+#
+# Alloy UI: http://localhost:12345
+
+services:
+  alloy:
+    image: grafana/alloy:latest
+    volumes:
+      - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - GRAFANA_LOKI_URL
+      - GRAFANA_LOKI_USER
+      - GRAFANA_LOKI_API_KEY
+    command: run --server.http.listen-addr=0.0.0.0:12345 /etc/alloy/config.alloy
+    ports:
+      - "12345:12345"
+    networks:
+      - net
+    restart: unless-stopped
+    profiles:
+      - grafana

--- a/docker-compose.loki-local.yml
+++ b/docker-compose.loki-local.yml
@@ -1,0 +1,54 @@
+# Local Loki stack overlay — runs Loki + Grafana UI + Alloy locally.
+# No Grafana Cloud account or credentials needed. Use for testing before
+# setting up production log shipping.
+#
+# Activate by stacking on top of your base compose file:
+#   make loki-emulator   # Mock APIs + local Loki stack
+#   make loki-live       # Live APIs + local Loki stack
+#
+# Access:
+#   Grafana UI:  http://localhost:3000  (anonymous admin, no login required)
+#   Loki API:    http://localhost:3100
+#   Alloy UI:    http://localhost:12345
+#
+# Query logs: Grafana → Explore → Loki → {service="backend"}
+
+services:
+  loki:
+    image: grafana/loki:latest
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+    networks:
+      - net
+    restart: unless-stopped
+
+  grafana-ui:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+    depends_on:
+      - loki
+    networks:
+      - net
+    restart: unless-stopped
+
+  alloy:
+    image: grafana/alloy:latest
+    volumes:
+      - ./alloy/config.loki-local.alloy:/etc/alloy/config.alloy:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: run --server.http.listen-addr=0.0.0.0:12345 /etc/alloy/config.alloy
+    ports:
+      - "12345:12345"
+    depends_on:
+      - loki
+    networks:
+      - net
+    restart: unless-stopped

--- a/docker-compose.redis.yml
+++ b/docker-compose.redis.yml
@@ -63,6 +63,8 @@ services:
       - REDIS_PASSWORD=
       - REDIS_DB=0
       - MESSAGE_INTERVAL_SECONDS=60
+      - LOG_FORMAT=${LOG_FORMAT:-json}
+      - LOG_LEVEL=${LOG_LEVEL:-info}
     env_file:
       - ./watchgameupdates/.env.redis
     depends_on:
@@ -86,6 +88,8 @@ services:
       - REDIS_ADDRESS=redis:6379
       - REDIS_PASSWORD=
       - REDIS_DB=0
+      - LOG_FORMAT=${LOG_FORMAT:-json}
+      - LOG_LEVEL=${LOG_LEVEL:-info}
     env_file:
       - ./watchgameupdates/.env.redis
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       - "8080:8080"
     environment:
       - PORT=8080
+      - LOG_FORMAT=${LOG_FORMAT:-json}
+      - LOG_LEVEL=${LOG_LEVEL:-info}
     depends_on:
       - cloudtasks-emulator
     networks:
@@ -30,6 +32,9 @@ services:
       context: ./watchgameupdates
       dockerfile: Dockerfile.scheduler
     image: schedulegametrackers:latest
+    environment:
+      - LOG_FORMAT=${LOG_FORMAT:-json}
+      - LOG_LEVEL=${LOG_LEVEL:-info}
     depends_on:
       - cloudtasks-emulator
       - backend

--- a/docs/grafana-loki-setup.md
+++ b/docs/grafana-loki-setup.md
@@ -1,0 +1,178 @@
+# Grafana Loki Log Shipping Setup
+
+This document covers how to test Grafana Loki log shipping locally, and how to configure it for production with Grafana Cloud. The app writes structured JSON logs to stdout (12-factor compliant). Grafana Alloy collects those logs from Docker and ships them to Loki — the Go code itself is unaware of the destination.
+
+---
+
+## Part 1: Local Testing (No Grafana Cloud Account Required)
+
+Use the local Loki stack to verify the full pipeline end-to-end before setting up any cloud infrastructure.
+
+### What runs
+
+| Service | URL | Purpose |
+|---|---|---|
+| Loki | http://localhost:3100 | Log storage |
+| Grafana UI | http://localhost:3000 | Log explorer (auto-configured, no login) |
+| Grafana Alloy | http://localhost:12345 | Log shipper pipeline UI |
+
+The Alloy config at `alloy/config.loki-local.alloy` sends logs to `http://loki:3100` with no auth. The Grafana datasource is auto-provisioned from `grafana/provisioning/datasources/loki.yaml`.
+
+### Steps
+
+**1. Start the stack**
+
+```bash
+# With mock game data APIs (recommended for first test)
+make loki-emulator
+
+# Or with live NHL/MoneyPuck APIs
+make loki-live
+```
+
+Both targets build the backend from source, pull the mock data image (emulator only), and start Loki, Grafana, and Alloy alongside the backend.
+
+**2. Verify Alloy is collecting logs**
+
+Open the Alloy pipeline UI at http://localhost:12345. You should see:
+- `discovery.docker.containers` — lists running containers as targets
+- `loki.source.docker.containers` — shows bytes received
+- `loki.write.local` — shows bytes sent to Loki
+
+If targets show `0`, wait 10–15 seconds for Alloy to discover containers.
+
+**3. Query logs in Grafana**
+
+1. Open http://localhost:3000
+2. Click **Explore** (compass icon in the left sidebar)
+3. Select the **Loki** data source (pre-configured)
+4. In the label filter, select `service = backend`
+5. Click **Run query**
+
+You should see JSON log lines from the backend container.
+
+**4. Query structured fields with LogQL**
+
+Because the backend emits JSON, Loki can parse log fields on query:
+
+```logql
+# All backend logs
+{service="backend"}
+
+# Filter by log level
+{service="backend"} | json | level="ERROR"
+
+# Filter by game ID
+{service="backend"} | json | game_id="2024030411"
+
+# Scheduler logs only
+{service="scheduler"}
+
+# All services
+{compose_project="backend"}
+```
+
+**5. Test with short intervals (faster log volume)**
+
+```bash
+# Set short poll interval to generate more log volume quickly
+MESSAGE_INTERVAL_SECONDS=10 make loki-emulator
+```
+
+**6. Stop**
+
+```bash
+make stop
+```
+
+---
+
+## Part 2: Production Setup (Grafana Cloud)
+
+### Prerequisites
+
+- A Grafana Cloud account (free tier available)
+- The backend running with `make live` or in production
+
+### Steps
+
+**1. Create a Grafana Cloud account**
+
+Sign up at https://grafana.com/auth/sign-up. A free account includes sufficient Loki storage for this use case.
+
+**2. Find your Loki credentials**
+
+1. Log in to Grafana Cloud at https://grafana.com/orgs/<your-org>
+2. Click your stack name → **Details**
+3. Scroll to the **Loki** section
+4. Note the **URL** (e.g. `https://logs-prod-006.grafana.net`) and **User** (numeric instance ID)
+5. Click **Generate now** under API Keys → create a key with **Logs Writer** role
+6. Copy the API key — it will not be shown again
+
+Alternatively, navigate to **Connections → Add new connection → Grafana Alloy** for guided instructions that include your credentials pre-filled.
+
+**3. Set credentials as environment variables**
+
+Add to your `.env.home` file (never commit credentials):
+
+```bash
+GRAFANA_LOKI_URL=https://logs-prod-006.grafana.net/loki/api/v1/push
+GRAFANA_LOKI_USER=123456
+GRAFANA_LOKI_API_KEY=glc_eyJ...
+```
+
+The Loki URL must end with `/loki/api/v1/push`.
+
+**4. Start the stack with Alloy**
+
+```bash
+# Cloud Tasks mode
+make grafana-live        # Live APIs + Alloy
+make grafana-emulator    # Mock APIs + Alloy (for testing)
+
+# Redis worker mode
+make grafana-redis       # Live APIs + Alloy
+make grafana-redis-test  # Mock APIs + Alloy (for testing)
+```
+
+**5. Verify Alloy is shipping**
+
+Open the Alloy pipeline UI at http://localhost:12345. Check that `loki.write.destination` shows bytes being sent. If you see errors, verify the URL ends with `/loki/api/v1/push` and the API key has the correct role.
+
+**6. Query logs in Grafana Cloud**
+
+1. Open your Grafana Cloud instance (e.g. `https://your-org.grafana.net`)
+2. Click **Explore** → select the **Loki** data source
+3. Query:
+
+```logql
+# All backend logs in the last hour
+{service="backend"}
+
+# Errors only
+{service="backend"} | json | level="ERROR"
+
+# Specific game
+{service="backend"} | json | game_id="2024030411"
+
+# Notification sent events
+{service="backend"} | json | msg="notification sent successfully"
+```
+
+### Security Notes
+
+- The `GRAFANA_LOKI_API_KEY` only needs **Logs Writer** role — do not use Admin keys
+- Never commit credentials to git; keep them in `.env.home` (already in `.gitignore`)
+- Rotate the API key periodically via the Grafana Cloud Access Policies UI
+- The Alloy container passes credentials via environment variables, not config files
+
+### Makefile quick reference
+
+| Command | What it does |
+|---|---|
+| `make loki-emulator` | Mock APIs + local Loki + Grafana UI (no cloud account needed) |
+| `make loki-live` | Live APIs + local Loki + Grafana UI |
+| `make grafana-emulator` | Mock APIs + Alloy → Grafana Cloud |
+| `make grafana-live` | Live APIs + Alloy → Grafana Cloud |
+| `make grafana-redis-test` | Redis + mock APIs + Alloy → Grafana Cloud |
+| `make grafana-redis` | Redis + live APIs + Alloy → Grafana Cloud |

--- a/grafana/provisioning/datasources/loki.yaml
+++ b/grafana/provisioning/datasources/loki.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: true
+    editable: false

--- a/watchgameupdates/.env.example
+++ b/watchgameupdates/.env.example
@@ -1,5 +1,9 @@
 APP_ENV=
 
+# Logging
+LOG_FORMAT=json          # "json" (default) or "text" for human-readable structured output
+LOG_LEVEL=info           # "debug", "info" (default), "warn", "error"
+
 # Cloud Tasks Configuration (HTTP mode: -mode=http)
 CLOUD_TASKS_EMULATOR_HOST=
 GCP_PROJECT_ID=
@@ -41,3 +45,10 @@ SCHEDULE_FILE=                 # Path to local JSON schedule file (empty = use A
 SCHEDULE_DATE=                 # Override target date YYYY-MM-DD (empty = today)
 GAME_MAX_DURATION_HOURS=5      # Hours after game start for execution window
 SCHEDULER_SHOULD_NOTIFY=true   # Enable Discord notifications for scheduled games
+
+# Grafana Cloud Loki (used by Grafana Alloy sidecar — not the Go app directly)
+# Run `make grafana-live` or `make grafana-emulator` to activate log shipping.
+# See docs/grafana-loki-setup.md for setup instructions.
+GRAFANA_LOKI_URL=        # e.g. https://logs-prod-006.grafana.net/loki/api/v1/push
+GRAFANA_LOKI_USER=       # Grafana Cloud numeric instance ID
+GRAFANA_LOKI_API_KEY=    # API key with "Logs Writer" role

--- a/watchgameupdates/cmd/enqueue/main.go
+++ b/watchgameupdates/cmd/enqueue/main.go
@@ -3,10 +3,12 @@ package main
 import (
 	"encoding/json"
 	"flag"
-	"log"
+	"log/slog"
+	"os"
 	"time"
 
 	"watchgameupdates/config"
+	"watchgameupdates/internal/logger"
 	"watchgameupdates/internal/models"
 	"watchgameupdates/internal/tasks"
 
@@ -14,6 +16,8 @@ import (
 )
 
 func main() {
+	slog.SetDefault(logger.New())
+
 	gameID := flag.String("game", "", "NHL game ID to watch (required)")
 	duration := flag.Duration("duration", 12*time.Minute, "Max execution duration")
 	delay := flag.Duration("delay", 0, "Delay before first execution")
@@ -21,7 +25,8 @@ func main() {
 	flag.Parse()
 
 	if *gameID == "" {
-		log.Fatal("--game flag is required")
+		slog.Error("--game flag is required")
+		os.Exit(1)
 	}
 
 	cfg := config.LoadConfig()
@@ -47,7 +52,8 @@ func main() {
 
 	task, err := tasks.NewWatchGameUpdatesTask(payload)
 	if err != nil {
-		log.Fatalf("Failed to create task: %v", err)
+		slog.Error("failed to create task", "error", err)
+		os.Exit(1)
 	}
 
 	opts := []asynq.Option{}
@@ -57,16 +63,18 @@ func main() {
 
 	info, err := client.Enqueue(task, opts...)
 	if err != nil {
-		log.Fatalf("Failed to enqueue task: %v", err)
+		slog.Error("failed to enqueue task", "error", err)
+		os.Exit(1)
 	}
 
 	payloadJSON, _ := json.MarshalIndent(payload, "", "  ")
-	log.Printf("Task enqueued successfully:")
-	log.Printf("  ID:       %s", info.ID)
-	log.Printf("  Queue:    %s", info.Queue)
-	log.Printf("  Game:     %s", *gameID)
-	log.Printf("  Payload:  %s", payloadJSON)
+	slog.Info("task enqueued successfully",
+		"id", info.ID,
+		"queue", info.Queue,
+		"game_id", *gameID,
+		"payload", string(payloadJSON),
+	)
 	if *delay > 0 {
-		log.Printf("  Delay:    %v", *delay)
+		slog.Info("task delayed", "delay", delay.String())
 	}
 }

--- a/watchgameupdates/cmd/schedulegametrackers/main.go
+++ b/watchgameupdates/cmd/schedulegametrackers/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
-	"log"
+	"log/slog"
+	"os"
 	"time"
 
 	"watchgameupdates/config"
+	"watchgameupdates/internal/logger"
 	"watchgameupdates/internal/notification"
 	"watchgameupdates/internal/queue"
 	"watchgameupdates/internal/schedule"
@@ -13,7 +15,7 @@ import (
 )
 
 func main() {
-	log.SetFlags(0)
+	slog.SetDefault(logger.New())
 
 	cfg := config.LoadConfig()
 
@@ -27,13 +29,14 @@ func main() {
 	var taskQueue scheduler.TaskEnqueuer
 	switch cfg.SchedulerQueue {
 	case "redis":
-		log.Printf("Scheduler queue: Redis (%s)", cfg.RedisAddress)
+		slog.Info("scheduler queue: Redis", "redis_address", cfg.RedisAddress)
 		taskQueue = queue.NewRedisQueue(cfg)
 	default:
-		log.Printf("Scheduler queue: Cloud Tasks")
+		slog.Info("scheduler queue: Cloud Tasks")
 		ctQueue, err := queue.NewCloudTasksQueue(ctx, cfg)
 		if err != nil {
-			log.Fatalf("Failed to create Cloud Tasks queue: %v", err)
+			slog.Error("failed to create Cloud Tasks queue", "error", err)
+			os.Exit(1)
 		}
 		taskQueue = ctQueue
 	}
@@ -49,8 +52,9 @@ func main() {
 	// Create and run scheduler
 	s := scheduler.New(fetcher, taskQueue, cfg.GameMaxDurationHours, cfg.SchedulerNotify, cfg.TeamFilter, notifService, cfg.IncludeLiveGames)
 	if err := s.Run(ctx, date); err != nil {
-		log.Fatalf("Scheduler failed: %v", err)
+		slog.Error("scheduler failed", "error", err)
+		os.Exit(1)
 	}
 
-	log.Println("Scheduler completed successfully")
+	slog.Info("scheduler completed successfully")
 }

--- a/watchgameupdates/cmd/watchgameupdates/main.go
+++ b/watchgameupdates/cmd/watchgameupdates/main.go
@@ -4,11 +4,13 @@ import (
 	"encoding/json"
 	"flag"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
+	"os"
 
 	"watchgameupdates/config"
 	"watchgameupdates/internal/handlers"
+	"watchgameupdates/internal/logger"
 	"watchgameupdates/internal/models"
 	"watchgameupdates/internal/notification"
 	"watchgameupdates/internal/notification/liveactivity"
@@ -26,7 +28,7 @@ func init() {
 	var err error
 	laNotifier, err = liveactivity.New()
 	if err != nil {
-		log.Printf("LiveActivity notifier not configured (normal if not enabled): %v", err)
+		slog.Info("LiveActivity notifier not configured (normal if not enabled)", "error", err)
 	}
 }
 
@@ -64,27 +66,28 @@ func httpHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func startHTTPMode(cfg *config.Config) {
-	log.Println("Starting in HTTP mode (Cloud Tasks)")
-
-	log.Printf("Config loaded:")
-	log.Printf("  APP_ENV:                    %s", cfg.Env)
-	log.Printf("  GCP_PROJECT_ID:             %s", cfg.ProjectID)
-	log.Printf("  GCP_LOCATION:               %s", cfg.LocationID)
-	log.Printf("  CLOUD_TASKS_QUEUE:          %s", cfg.QueueID)
-	log.Printf("  USE_TASKS_EMULATOR:         %v", cfg.UseEmulator)
-	log.Printf("  CLOUD_TASKS_EMULATOR_HOST:  %s", cfg.CloudTasksAddress)
-	log.Printf("  HANDLER_HOST:               %s", cfg.HandlerAddress)
-	log.Printf("  MESSAGE_INTERVAL_SECONDS:   %d", cfg.MessageIntervalSeconds)
-	log.Printf("  PERIOD_END_INTERVAL_SECONDS:%d", cfg.PeriodEndIntervalSeconds)
+	slog.Info("starting in HTTP mode (Cloud Tasks)")
+	slog.Info("config loaded",
+		"app_env", cfg.Env,
+		"gcp_project_id", cfg.ProjectID,
+		"gcp_location", cfg.LocationID,
+		"cloud_tasks_queue", cfg.QueueID,
+		"use_tasks_emulator", cfg.UseEmulator,
+		"cloud_tasks_emulator_host", cfg.CloudTasksAddress,
+		"handler_host", cfg.HandlerAddress,
+		"message_interval_seconds", cfg.MessageIntervalSeconds,
+		"period_end_interval_seconds", cfg.PeriodEndIntervalSeconds,
+	)
 
 	funcframework.RegisterHTTPFunction("/", httpHandler)
 	if err := funcframework.Start("8080"); err != nil {
-		log.Fatalf("Failed to start function: %v", err)
+		slog.Error("failed to start function", "error", err)
+		os.Exit(1)
 	}
 }
 
 func startWorkerMode(cfg *config.Config) {
-	log.Printf("Starting in worker mode (Redis at %s)", cfg.RedisAddress)
+	slog.Info("starting in worker mode", "redis_address", cfg.RedisAddress)
 
 	redisOpt := asynq.RedisClientOpt{
 		Addr:     cfg.RedisAddress,
@@ -106,16 +109,16 @@ func startWorkerMode(cfg *config.Config) {
 	handler := tasks.NewWatchGameUpdatesHandler(cfg, client)
 	mux.HandleFunc(tasks.TypeWatchGameUpdates, handler.ProcessTask)
 
-	log.Printf("Asynq worker ready, listening for tasks...")
+	slog.Info("asynq worker ready, listening for tasks")
 
 	if err := srv.Run(mux); err != nil {
-		log.Fatalf("Failed to start asynq worker: %v", err)
+		slog.Error("failed to start asynq worker", "error", err)
+		os.Exit(1)
 	}
 }
 
 func main() {
-	// Remove timestamp prefix from logs - Docker/structured logging handles timestamps
-	log.SetFlags(0)
+	slog.SetDefault(logger.New())
 
 	mode := flag.String("mode", "http", "Run mode: 'http' for Cloud Tasks handler, 'worker' for Redis queue worker")
 	flag.Parse()
@@ -128,6 +131,7 @@ func main() {
 	case "worker":
 		startWorkerMode(cfg)
 	default:
-		log.Fatalf("Unknown mode: %s. Use 'http' or 'worker'.", *mode)
+		slog.Error("unknown mode", "mode", *mode)
+		os.Exit(1)
 	}
 }

--- a/watchgameupdates/internal/handlers/watchgameupdates_handler.go
+++ b/watchgameupdates/internal/handlers/watchgameupdates_handler.go
@@ -5,8 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
+	"os"
 	"time"
 
 	"watchgameupdates/config"
@@ -31,7 +32,7 @@ func WatchGameUpdatesHandler(
 		return
 	}
 
-	log.Printf("Raw body: %s", body)
+	slog.Debug("received request body", "game_id", payload.Game.ID, "body", string(body))
 
 	// Check execution window using shared logic
 	skip, err := services.ShouldSkipExecution(payload)
@@ -54,7 +55,7 @@ func WatchGameUpdatesHandler(
 		cfg := config.LoadConfig()
 		interval := services.RescheduleInterval(result.LastPlay, result.MaxPeriods, cfg)
 		if err := scheduleNextCheck(payload, interval); err != nil {
-			log.Printf("Failed to schedule next check: %v", err)
+			slog.Error("failed to schedule next check", "game_id", payload.Game.ID, "error", err)
 			http.Error(w, "Failed to schedule next check", http.StatusInternalServerError)
 			return
 		}
@@ -70,7 +71,8 @@ func scheduleNextCheck(payload models.Payload, interval time.Duration) error {
 
 	tasksClient, err := tasks.NewCloudTasksClient(tasksCtx, cfg)
 	if err != nil {
-		log.Fatalf("failed to create tasks client: %v", err)
+		slog.Error("failed to create tasks client", "error", err)
+		os.Exit(1)
 	}
 	defer tasksClient.Close()
 
@@ -88,9 +90,9 @@ func scheduleNextCheck(payload models.Payload, interval time.Duration) error {
 	queuePath := fmt.Sprintf("projects/%s/locations/%s/queues/%s", projectID, location, queueName)
 
 	if payload.ExecutionEnd != nil {
-		log.Printf("Max execution time for game %s is set to %s", payload.Game.ID, *payload.ExecutionEnd)
+		slog.Debug("scheduling next check", "game_id", payload.Game.ID, "execution_end", *payload.ExecutionEnd)
 	} else {
-		log.Printf("Max execution time for game %s is not set", payload.Game.ID)
+		slog.Debug("scheduling next check, no execution end set", "game_id", payload.Game.ID)
 	}
 
 	task := &taskspb.Task{
@@ -112,13 +114,13 @@ func scheduleNextCheck(payload models.Payload, interval time.Duration) error {
 		Task:   task,
 	}
 
-	log.Printf("Sending task creation request in %ds for game %s to Cloud Tasks queue %s", int(interval.Seconds()), payload.Game.ID, queuePath)
+	slog.Info("enqueuing next check task", "game_id", payload.Game.ID, "interval_seconds", int(interval.Seconds()), "queue", queuePath)
 
 	_, err = tasksClient.CreateTask(tasksCtx, req)
 	if err != nil {
 		return fmt.Errorf("failed to create reschedule task: %w", err)
 	}
 
-	log.Printf("Successfully scheduled next check task for game %s at %v", payload.Game.ID, scheduleTime.AsTime().Format(time.RFC3339))
+	slog.Info("next check scheduled", "game_id", payload.Game.ID, "scheduled_at", scheduleTime.AsTime().Format(time.RFC3339))
 	return nil
 }

--- a/watchgameupdates/internal/logger/logger.go
+++ b/watchgameupdates/internal/logger/logger.go
@@ -1,0 +1,38 @@
+package logger
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// New returns a configured *slog.Logger driven by LOG_FORMAT and LOG_LEVEL env vars.
+// LOG_FORMAT: "json" (default) or "text" for human-readable structured output.
+// LOG_LEVEL:  "debug", "info" (default), "warn", or "error".
+// Call slog.SetDefault(logger.New()) in main so all packages using slog share the config.
+func New() *slog.Logger {
+	level := parseLevel(os.Getenv("LOG_LEVEL"))
+	opts := &slog.HandlerOptions{Level: level}
+
+	var handler slog.Handler
+	if strings.ToLower(os.Getenv("LOG_FORMAT")) == "text" {
+		handler = slog.NewTextHandler(os.Stdout, opts)
+	} else {
+		handler = slog.NewJSONHandler(os.Stdout, opts)
+	}
+
+	return slog.New(handler)
+}
+
+func parseLevel(s string) slog.Level {
+	switch strings.ToLower(s) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/watchgameupdates/internal/notification/service.go
+++ b/watchgameupdates/internal/notification/service.go
@@ -2,7 +2,7 @@ package notification
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -43,23 +43,23 @@ func (s *Service) discoverNotifiers() {
 func (s *Service) tryCreateDiscordNotifier() Notifier {
 	config, err := LoadDiscordConfigFromEnv()
 	if err != nil {
-		log.Printf("Discord notifier config not found or invalid: %v", err)
+		slog.Debug("Discord notifier not configured", "reason", err)
 		return nil
 	}
 
 	notifier, err := NewDiscordNotifier(config)
 	if err != nil {
-		log.Printf("Failed to create Discord notifier: %v", err)
+		slog.Error("failed to create Discord notifier", "error", err)
 		return nil
 	}
 
-	log.Printf("Discord notifier created successfully")
+	slog.Info("Discord notifier created successfully")
 	return notifier
 }
 
 func (s *Service) SendGameEventNotifications(game Game, gameData map[string]string) {
 	if !s.shouldNotify {
-		log.Printf("Notifications disabled for this service instance, skipping game event notifications")
+		slog.Debug("notifications disabled, skipping game event notifications")
 		return
 	}
 
@@ -69,7 +69,7 @@ func (s *Service) SendGameEventNotifications(game Game, gameData map[string]stri
 			if val, ok := gameData[key]; ok {
 				data[key] = val
 			} else {
-				log.Printf("WARNING: Required data key '%s' not found in game data for notifier %d", key, i)
+				slog.Warn("required data key missing for notifier", "key", key, "notifier_index", i)
 			}
 		}
 
@@ -85,12 +85,12 @@ func (s *Service) SendGameEventNotifications(game Game, gameData map[string]stri
 
 func (s *Service) SendGameUpdate(homeTeam, awayTeam, homeXG, awayXG, homeGoals, awayGoals string) {
 	if !s.shouldNotify {
-		log.Printf("Notifications disabled for this service instance, skipping game update notifications")
+		slog.Debug("notifications disabled, skipping game update notification")
 		return
 	}
 
 	if len(s.notifiers) == 0 {
-		log.Printf("No notifiers configured, skipping notification")
+		slog.Debug("no notifiers configured, skipping notification")
 		return
 	}
 
@@ -117,31 +117,31 @@ func (s *Service) sendToNotifier(notifier Notifier, req NotificationRequest, ind
 	message := notifier.FormatMessage(req)
 	resultChan, err := notifier.SendNotification(ctx, message)
 	if err != nil {
-		log.Printf("Notifier %d failed to send notification: %v", index, err)
+		slog.Error("notifier failed to send notification", "notifier_index", index, "error", err)
 		return
 	}
 
 	select {
 	case result := <-resultChan:
 		if !result.Success {
-			log.Printf("Notifier %d notification failed: %v", index, result.Error)
+			slog.Error("notification send failed", "notifier_index", index, "error", result.Error)
 		} else {
-			log.Printf("Notifier %d notification sent successfully: %s", index, result.ID)
+			slog.Info("notification sent successfully", "notifier_index", index, "message_id", result.ID)
 		}
 	case <-ctx.Done():
-		log.Printf("Notifier %d notification timed out", index)
+		slog.Warn("notification timed out", "notifier_index", index)
 	}
 }
 
 // SendMessage sends a plain-text message to all configured notifiers and waits for completion.
 func (s *Service) SendMessage(ctx context.Context, message string) {
 	if !s.shouldNotify {
-		log.Printf("Notifications disabled for this service instance, skipping message")
+		slog.Debug("notifications disabled, skipping message")
 		return
 	}
 
 	if len(s.notifiers) == 0 {
-		log.Printf("No notifiers configured, skipping notification")
+		slog.Debug("no notifiers configured, skipping notification")
 		return
 	}
 
@@ -155,19 +155,19 @@ func (s *Service) SendMessage(ctx context.Context, message string) {
 
 			resultChan, err := n.SendNotification(notifCtx, message)
 			if err != nil {
-				log.Printf("Notifier %d failed to send message: %v", idx, err)
+				slog.Error("notifier failed to send message", "notifier_index", idx, "error", err)
 				return
 			}
 
 			select {
 			case result := <-resultChan:
 				if !result.Success {
-					log.Printf("Notifier %d message failed: %v", idx, result.Error)
+					slog.Error("message send failed", "notifier_index", idx, "error", result.Error)
 				} else {
-					log.Printf("Notifier %d message sent successfully: %s", idx, result.ID)
+					slog.Info("message sent successfully", "notifier_index", idx, "message_id", result.ID)
 				}
 			case <-notifCtx.Done():
-				log.Printf("Notifier %d message timed out", idx)
+				slog.Warn("message send timed out", "notifier_index", idx)
 			}
 		}(notifier, i)
 	}
@@ -179,7 +179,7 @@ func (s *Service) Close() error {
 	var lastErr error
 	for _, notifier := range s.notifiers {
 		if err := notifier.Close(); err != nil {
-			log.Printf("Error closing notifier: %v", err)
+			slog.Error("error closing notifier", "error", err)
 			lastErr = err
 		}
 	}

--- a/watchgameupdates/internal/queue/cloudtasks.go
+++ b/watchgameupdates/internal/queue/cloudtasks.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"time"
 
 	"watchgameupdates/config"
@@ -58,11 +58,12 @@ func (q *CloudTasksQueue) Enqueue(ctx context.Context, payload models.Payload, d
 		Task:   task,
 	}
 
-	log.Printf("Enqueuing task for game %s (%s vs %s) scheduled at %s",
-		payload.Game.ID,
-		payload.Game.AwayTeam.Abbrev,
-		payload.Game.HomeTeam.Abbrev,
-		deliverAt.Format(time.RFC3339))
+	slog.Info("enqueuing Cloud Tasks task",
+		"game_id", payload.Game.ID,
+		"away", payload.Game.AwayTeam.Abbrev,
+		"home", payload.Game.HomeTeam.Abbrev,
+		"deliver_at", deliverAt.Format(time.RFC3339),
+	)
 
 	_, err = q.client.CreateTask(ctx, req)
 	if err != nil {

--- a/watchgameupdates/internal/queue/redis.go
+++ b/watchgameupdates/internal/queue/redis.go
@@ -3,7 +3,7 @@ package queue
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"time"
 
 	"watchgameupdates/config"
@@ -44,12 +44,13 @@ func (q *RedisQueue) Enqueue(_ context.Context, payload models.Payload, deliverA
 		return fmt.Errorf("failed to enqueue task: %w", err)
 	}
 
-	log.Printf("Enqueuing task for game %s (%s vs %s) scheduled at %s, task ID: %s",
-		payload.Game.ID,
-		payload.Game.AwayTeam.Abbrev,
-		payload.Game.HomeTeam.Abbrev,
-		deliverAt.Format(time.RFC3339),
-		info.ID)
+	slog.Info("enqueuing Redis task",
+		"game_id", payload.Game.ID,
+		"away", payload.Game.AwayTeam.Abbrev,
+		"home", payload.Game.HomeTeam.Abbrev,
+		"deliver_at", deliverAt.Format(time.RFC3339),
+		"task_id", info.ID,
+	)
 
 	return nil
 }

--- a/watchgameupdates/internal/scheduler/scheduler.go
+++ b/watchgameupdates/internal/scheduler/scheduler.go
@@ -3,7 +3,7 @@ package scheduler
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"strconv"
 	"time"
 
@@ -56,7 +56,7 @@ func New(fetcher schedule.ScheduleFetcher, q TaskEnqueuer, gameMaxDurationHours 
 
 // Run fetches the schedule for the given date and enqueues a task for each future game.
 func (s *Scheduler) Run(ctx context.Context, date string) error {
-	log.Printf("Fetching schedule for %s", date)
+	slog.Info("fetching schedule", "date", date)
 
 	games, err := s.fetcher.FetchSchedule(ctx, date)
 	if err != nil {
@@ -64,36 +64,47 @@ func (s *Scheduler) Run(ctx context.Context, date string) error {
 	}
 
 	if len(games) == 0 {
-		log.Printf("No games found for %s", date)
+		slog.Info("no games found", "date", date)
 		return nil
 	}
 
-	log.Printf("Found %d games for %s", len(games), date)
+	slog.Info("games found", "count", len(games), "date", date)
 
 	scheduled := 0
 	var scheduledGames []schedule.ScheduleGame
 	for _, game := range games {
 		if s.teamFilter != "" && game.HomeTeam.Abbrev != s.teamFilter && game.AwayTeam.Abbrev != s.teamFilter {
-			log.Printf("Skipping game %d (%s vs %s) - neither team matches filter %s",
-				game.ID, game.AwayTeam.Abbrev, game.HomeTeam.Abbrev, s.teamFilter)
+			slog.Debug("skipping game, team filter mismatch",
+				"game_id", game.ID,
+				"away", game.AwayTeam.Abbrev,
+				"home", game.HomeTeam.Abbrev,
+				"filter", s.teamFilter,
+			)
 			continue
 		}
 
 		isLive := game.GameState == gameStateLIVE
 		if game.GameState != gameStateFUT && game.GameState != gameStatePRE && !isLive {
-			log.Printf("Skipping game %d (%s vs %s) - state is %s, not FUT or PRE",
-				game.ID, game.AwayTeam.Abbrev, game.HomeTeam.Abbrev, game.GameState)
+			slog.Debug("skipping game, unexpected state",
+				"game_id", game.ID,
+				"away", game.AwayTeam.Abbrev,
+				"home", game.HomeTeam.Abbrev,
+				"state", game.GameState,
+			)
 			continue
 		}
 		if isLive && !s.includeLiveGames {
-			log.Printf("Skipping game %d (%s vs %s) - state is LIVE (set INCLUDE_LIVE_GAMES=true to monitor)",
-				game.ID, game.AwayTeam.Abbrev, game.HomeTeam.Abbrev)
+			slog.Info("skipping live game (set INCLUDE_LIVE_GAMES=true to monitor)",
+				"game_id", game.ID,
+				"away", game.AwayTeam.Abbrev,
+				"home", game.HomeTeam.Abbrev,
+			)
 			continue
 		}
 
 		startTime, err := time.Parse(time.RFC3339, game.StartTimeUTC)
 		if err != nil {
-			log.Printf("Failed to parse start time for game %d: %v", game.ID, err)
+			slog.Error("failed to parse game start time", "game_id", game.ID, "error", err)
 			continue
 		}
 
@@ -121,7 +132,7 @@ func (s *Scheduler) Run(ctx context.Context, date string) error {
 		}
 
 		if err := s.queue.Enqueue(ctx, payload, deliverAt); err != nil {
-			log.Printf("Failed to enqueue task for game %d: %v", game.ID, err)
+			slog.Error("failed to enqueue task", "game_id", game.ID, "error", err)
 			continue
 		}
 
@@ -129,7 +140,7 @@ func (s *Scheduler) Run(ctx context.Context, date string) error {
 		scheduled++
 	}
 
-	log.Printf("Successfully scheduled %d/%d tasks for %s", scheduled, len(games), date)
+	slog.Info("scheduling complete", "scheduled", scheduled, "total", len(games), "date", date)
 
 	if scheduled > 0 && s.notifier != nil {
 		s.notifier.SendMessage(ctx, formatSchedulerSummary(date, scheduledGames))

--- a/watchgameupdates/internal/services/gameprocessor.go
+++ b/watchgameupdates/internal/services/gameprocessor.go
@@ -2,7 +2,7 @@ package services
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"strconv"
 	"time"
 
@@ -33,11 +33,11 @@ func ShouldSkipExecution(payload models.Payload) (bool, error) {
 			return true, fmt.Errorf("invalid execution_end format: %w", err)
 		}
 		if time.Now().After(executionEnd) {
-			log.Printf("Current time is after execution end (%s). Skipping execution.", executionEnd.Format(time.RFC3339))
+			slog.Info("current time is past execution end, skipping", "execution_end", executionEnd.Format(time.RFC3339))
 			return true, nil
 		}
 	} else {
-		log.Println("Max execution time not set, proceeding without time check.")
+		slog.Debug("no execution end set, proceeding without time check")
 	}
 	return false, nil
 }
@@ -57,12 +57,12 @@ func (gp *GameProcessor) ProcessGameUpdate(payload models.Payload) ProcessResult
 	lastPlay, maxPeriods := FetchPlayByPlay(payload.Game.ID)
 
 	if _, ok := recomputeTypes[lastPlay.TypeDescKey]; ok {
-		log.Printf("Processing play type '%s' for game %s - fetching MoneyPuck data", lastPlay.TypeDescKey, payload.Game.ID)
+		slog.Info("processing play type, fetching MoneyPuck data", "play_type", lastPlay.TypeDescKey, "game_id", payload.Game.ID)
 
 		requiredKeys := gp.NotificationService.GetAllRequiredDataKeys()
 		gameData, err := gp.Fetcher.FetchAndParseGameData(payload.Game.ID, requiredKeys)
 		if err != nil {
-			log.Printf("ERROR: Failed to fetch and parse MoneyPuck data for game %s: %v", payload.Game.ID, err)
+			slog.Error("failed to fetch MoneyPuck data", "game_id", payload.Game.ID, "error", err)
 		}
 
 		// Populate game state (period/time) from play-by-play data.
@@ -77,7 +77,7 @@ func (gp *GameProcessor) ProcessGameUpdate(payload models.Payload) ProcessResult
 			awayGoals, awayGOK := gameData["awayTeamGoals"]
 			if homeGOK && awayGOK && homeGoals == awayGoals {
 				if shootoutErr := AdjustScoreForShootout(gameData); shootoutErr != nil {
-					log.Printf("Failed to adjust score for shootout: %v", shootoutErr)
+					slog.Error("failed to adjust score for shootout", "game_id", payload.Game.ID, "error", shootoutErr)
 				}
 			}
 		}
@@ -86,7 +86,7 @@ func (gp *GameProcessor) ProcessGameUpdate(payload models.Payload) ProcessResult
 	}
 
 	shouldReschedule := ShouldReschedule(payload, lastPlay)
-	log.Printf("Last play type: %s, Should reschedule: %v\n", lastPlay.TypeDescKey, shouldReschedule)
+	slog.Info("game update processed", "game_id", payload.Game.ID, "last_play_type", lastPlay.TypeDescKey, "should_reschedule", shouldReschedule)
 
 	return ProcessResult{
 		ShouldReschedule: shouldReschedule,

--- a/watchgameupdates/internal/services/playbyplay.go
+++ b/watchgameupdates/internal/services/playbyplay.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"watchgameupdates/internal/models"
@@ -20,23 +20,19 @@ func FetchPlayByPlay(gameID string) (lastPlay models.Play, maxPeriods *int) {
 	playByPlayUrl := fmt.Sprintf("%s/v1/gamecenter/%s/play-by-play", playByPlayAPIBaseURL, gameID)
 	resp, err := http.Get(playByPlayUrl)
 	if err != nil {
-		log.Printf("Failed to fetch play-by-play data: %v", err)
-		// http.Error(w, "Failed to fetch play-by-play data", http.StatusInternalServerError)
+		slog.Error("failed to fetch play-by-play data", "game_id", gameID, "error", err)
 		return
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		log.Printf("Failed to fetch play-by-play data, status code: %d", resp.StatusCode)
-		// http.Error(w, "Failed to fetch play-by-play data", http.StatusInternalServerError)
+		slog.Error("play-by-play request returned non-200", "game_id", gameID, "status_code", resp.StatusCode)
 		return
 	}
 
-	// Display respnse body for debugging
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Printf("Failed to read response body: %v", err)
-		// http.Error(w, "Failed to read response body", http.StatusInternalServerError)
+		slog.Error("failed to read play-by-play response body", "game_id", gameID, "error", err)
 		return
 	}
 	var data models.PlayByPlayResponse
@@ -45,12 +41,11 @@ func FetchPlayByPlay(gameID string) (lastPlay models.Play, maxPeriods *int) {
 	}
 
 	if len(data.Plays) == 0 {
-		log.Printf("No plays found for GameID: %s", gameID)
-		// http.Error(w, "No plays found for the game", http.StatusNotFound)
+		slog.Warn("no plays found for game", "game_id", gameID)
 		return
 	}
 
 	lastPlay = data.Plays[len(data.Plays)-1]
-	log.Printf("Last play type: %s, regular season: %t", lastPlay.TypeDescKey, data.MaxPeriods != nil)
+	slog.Debug("fetched play-by-play", "game_id", gameID, "last_play_type", lastPlay.TypeDescKey, "regular_season", data.MaxPeriods != nil)
 	return lastPlay, data.MaxPeriods
 }

--- a/watchgameupdates/internal/services/rescheduler.go
+++ b/watchgameupdates/internal/services/rescheduler.go
@@ -1,7 +1,7 @@
 package services
 
 import (
-	"log"
+	"log/slog"
 	"time"
 	"watchgameupdates/internal/models"
 )
@@ -10,13 +10,13 @@ func ShouldReschedule(payload models.Payload, lastPlay models.Play) bool {
 	if payload.ExecutionEnd != nil {
 		executionEnd, err := time.Parse(time.RFC3339, *payload.ExecutionEnd)
 		if err != nil {
-			log.Printf("Error parsing executionEnd: %v", err)
+			slog.Error("error parsing executionEnd", "error", err)
 		} else if time.Now().After(executionEnd) {
-			log.Printf("Max execution time (%s) is set and has been reached. Do not reschedule.", executionEnd.Format(time.RFC3339))
+			slog.Info("execution end reached, not rescheduling", "execution_end", executionEnd.Format(time.RFC3339))
 			return false
 		}
 	} else {
-		log.Println("Max execution time not set, proceeding without time check.")
+		slog.Debug("no execution end set, proceeding without time check")
 	}
 
 	if lastPlay.TypeDescKey != "game-end" {

--- a/watchgameupdates/internal/tasks/handler.go
+++ b/watchgameupdates/internal/tasks/handler.go
@@ -3,7 +3,7 @@ package tasks
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"time"
 
 	"watchgameupdates/config"
@@ -33,21 +33,21 @@ func (h *WatchGameUpdatesHandler) ProcessTask(ctx context.Context, t *asynq.Task
 	payload, err := ParseWatchGameUpdatesPayload(t)
 	if err != nil {
 		// Poison pill: malformed JSON will never succeed on retry. Drop the task.
-		log.Printf("Dropping task with invalid payload: %v", err)
+		slog.Error("dropping task with invalid payload", "error", err)
 		return nil
 	}
 
-	log.Printf("Processing task for game %s", payload.Game.ID)
+	slog.Info("processing task", "game_id", payload.Game.ID)
 
 	// Check execution window
 	skip, err := services.ShouldSkipExecution(payload)
 	if err != nil {
 		// Poison pill: malformed ExecutionEnd will never parse on retry. Drop the task.
-		log.Printf("Dropping task for game %s with invalid execution window: %v", payload.Game.ID, err)
+		slog.Error("dropping task with invalid execution window", "game_id", payload.Game.ID, "error", err)
 		return nil
 	}
 	if skip {
-		log.Printf("Execution window expired for game %s, task complete.", payload.Game.ID)
+		slog.Info("execution window expired, task complete", "game_id", payload.Game.ID)
 		return nil
 	}
 
@@ -89,7 +89,6 @@ func (h *WatchGameUpdatesHandler) scheduleNextCheck(payload models.Payload) erro
 		return fmt.Errorf("failed to enqueue task: %w", err)
 	}
 
-	log.Printf("Scheduled next check for game %s, task ID: %s, processing in: %v",
-		payload.Game.ID, info.ID, interval)
+	slog.Info("next check scheduled", "game_id", payload.Game.ID, "task_id", info.ID, "interval", interval.String())
 	return nil
 }


### PR DESCRIPTION
Migrate all log calls from stdlib log package to log/slog (Go 1.21+
builtin, zero new dependencies) with structured key-value fields
(game_id, error, play_type, etc.) for richer querying in Grafana Loki.

Add Grafana Alloy sidecar configuration that reads Docker container
stdout and ships to Grafana Cloud Loki, keeping the app itself
12-factor compliant (logs as event streams, no direct Loki push).

- internal/logger: New() returns slog.Logger driven by LOG_FORMAT
  (json/text) and LOG_LEVEL env vars; called once in each cmd main
- All internal packages: log.Printf → slog.Info/Error/Warn/Debug with
  structured fields; log.Fatalf → slog.Error + os.Exit(1)
- alloy/config.alloy: Alloy pipeline for Grafana Cloud Loki
- alloy/config.loki-local.alloy: Alloy pipeline for local Loki
- docker-compose.grafana.yml: Alloy sidecar overlay (profile: grafana)
- docker-compose.loki-local.yml: Local Loki + Grafana UI stack
- grafana/provisioning/datasources/loki.yaml: Auto-provision Loki
- docker-compose.yml, docker-compose.redis.yml: LOG_FORMAT/LOG_LEVEL
  passthrough via ${LOG_FORMAT:-json} variable substitution
- Makefile: LOG_FORMAT/LOG_LEVEL vars, grafana-*, loki-*,
  schedule-fake-team, redis-schedule-fake-team targets
- docs/grafana-loki-setup.md: Local and production setup guide
- .env.example, CLAUDE.md, README.md: Document new env vars and targets