### PR TITLE
ci(deploy): add static Kubernetes manifest validation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,22 @@ jobs:
           fi
           echo "tag=${BRANCH}-${SHA}" >> "$GITHUB_OUTPUT"
 
+      - name: Validate manifests
+        env:
+          IMAGE_TAG: ${{ steps.image-tag.outputs.tag }}
+        run: |
+          mkdir rendered
+          for f in k8s/deployment-handler.yaml k8s/cronjob-scheduler.yaml; do
+            envsubst < "$f" > "rendered/$(basename "$f")"
+          done
+          cp k8s/deployment-cloudtasks.yaml k8s/namespace.yaml \
+             k8s/configmap.yaml k8s/service-backend.yaml k8s/service-cloudtasks.yaml \
+             rendered/
+          for f in rendered/*.yaml; do
+            echo "Checking: $f"
+            kubectl apply --dry-run=client -f "$f"
+          done
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/validate-manifests.yml
+++ b/.github/workflows/validate-manifests.yml
@@ -1,0 +1,33 @@
+name: Validate Kubernetes Manifests
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  validate:
+    name: Validate K8s Manifests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install kubeconform
+        run: |
+          curl -sLo kubeconform.tar.gz \
+            https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz
+          tar xf kubeconform.tar.gz kubeconform
+          sudo install kubeconform /usr/local/bin/kubeconform
+
+      - name: Render and validate manifests
+        env:
+          IMAGE_TAG: ci-validate
+        run: |
+          mkdir rendered
+          for f in k8s/*.yaml; do
+            envsubst < "$f" > "rendered/$(basename "$f")"
+          done
+          kubeconform -strict -summary -output pretty rendered/


### PR DESCRIPTION
Add a dedicated validate-manifests workflow that runs kubeconform
(strict schema validation) on every PR against k8s/*.yaml, with
IMAGE_TAG substituted via envsubst before checking.

Also add a kubectl apply --dry-run=client gate in the deploy workflow
that runs before any kubectl apply, using the real IMAGE_TAG so the
rendered manifests are exactly what will be applied.