### PR TITLE
fix(docker): use ENTRYPOINT for handler/scheduler/worker images

### DIFF
--- a/watchgameupdates/Dockerfile
+++ b/watchgameupdates/Dockerfile
@@ -18,4 +18,5 @@ COPY --from=builder /app/main .
 ENV PORT=8080
 EXPOSE 8080
 
-CMD ["/main"]
+ENTRYPOINT ["/main"]
+CMD ["-mode=http"]

--- a/watchgameupdates/Dockerfile.scheduler
+++ b/watchgameupdates/Dockerfile.scheduler
@@ -16,4 +16,4 @@ WORKDIR /
 
 COPY --from=builder /app/scheduler .
 
-CMD ["/scheduler"]
+ENTRYPOINT ["/scheduler"]

--- a/watchgameupdates/Dockerfile.worker
+++ b/watchgameupdates/Dockerfile.worker
@@ -15,4 +15,5 @@ FROM gcr.io/distroless/static
 WORKDIR /
 COPY --from=builder /app/main .
 
-CMD ["/main", "-mode=worker"]
+ENTRYPOINT ["/main"]
+CMD ["-mode=worker"]


### PR DESCRIPTION
## Summary

- **Root cause:** `k8s/deployment-handler.yaml` sets `args: ["-mode=http"]`, which in Kubernetes overrides Dockerfile `CMD` entirely. Without an `ENTRYPOINT`, the container tried to exec `-mode=http` as the binary — causing CrashLoopBackOff (169 restarts over 14h) and every deploy to time out waiting for the rollout.
- Introduced in 5712b51 when the `args:` line was added to pin http mode without a corresponding `ENTRYPOINT` in the Dockerfile.
- Applies the Docker idiom: `ENTRYPOINT ["/binary"]` + `CMD ["default-args"]`. Kubernetes `args:` then correctly overrides only the args.
- Same fix applied consistently to all three Dockerfiles (handler, scheduler, worker).

## Test plan

- [ ] docker-push workflow builds images from this branch successfully
- [ ] deploy workflow runs from this branch and `kubectl rollout status` completes without timeout
- [ ] handler pod comes up healthy (no CrashLoopBackOff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)