### PR TITLE
fix(notification): plumb team abbrevs and last play type to notifiers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ watch: ## E2E live test for a team: schedules today's real game and follows logs
 schedule-team: ## Run scheduler for one team (usage: make schedule-team TEAM=TOR [DATE=2026-05-21])
 	@if [ -z "$(TEAM)" ]; then printf "Error: TEAM is required. Usage: make schedule-team TEAM=TOR\n"; exit 1; fi
 	@printf "$(BLUE)[INFO]$(NC) Running scheduler for team $(TEAM)...\n"
-	@podman-compose -f docker-compose.yml -f docker-compose.live.yml run --rm \
+	@podman-compose -f docker-compose.yml -f docker-compose.live.yml --profile scheduler run --rm --no-deps --build \
 	  -e TEAM_FILTER=$(TEAM) \
 	  -e INCLUDE_LIVE_GAMES=true \
 	  $(if $(DATE),-e SCHEDULE_DATE=$(DATE),) \

--- a/watchgameupdates/internal/notification/service.go
+++ b/watchgameupdates/internal/notification/service.go
@@ -63,10 +63,20 @@ func (s *Service) SendGameEventNotifications(game Game, gameData map[string]stri
 		return
 	}
 
+	// Fields sourced from Game (not the MoneyPuck data map) — notifiers that
+	// declare these in GetRequiredDataKeys can read them from a single map.
+	enriched := map[string]string{
+		"homeTeamAbbrev": game.HomeTeam.Abbrev,
+		"awayTeamAbbrev": game.AwayTeam.Abbrev,
+	}
+	for k, v := range gameData {
+		enriched[k] = v
+	}
+
 	for i, notifier := range s.notifiers {
 		data := map[string]string{}
 		for _, key := range notifier.GetRequiredDataKeys() {
-			if val, ok := gameData[key]; ok {
+			if val, ok := enriched[key]; ok {
 				data[key] = val
 			} else {
 				log.Printf("WARNING: Required data key '%s' not found in game data for notifier %d", key, i)

--- a/watchgameupdates/internal/services/gameprocessor.go
+++ b/watchgameupdates/internal/services/gameprocessor.go
@@ -65,9 +65,10 @@ func (gp *GameProcessor) ProcessGameUpdate(payload models.Payload) ProcessResult
 			log.Printf("ERROR: Failed to fetch and parse MoneyPuck data for game %s: %v", payload.Game.ID, err)
 		}
 
-		// Populate game state (period/time) from play-by-play data.
+		// Populate fields sourced from play-by-play data (not MoneyPuck CSV).
 		if gameData != nil {
 			gameData["gameState"] = FormatGameState(lastPlay)
+			gameData["lastPlayType"] = lastPlay.TypeDescKey
 		}
 
 		// Only run shootout adjustment when the fetch succeeded — a partial map


### PR DESCRIPTION
## Summary
- Enriches the per-notifier data map in `SendGameEventNotifications` with `homeTeamAbbrev` / `awayTeamAbbrev` from the `Game` struct, so notifiers that declare those keys (Live Activity APNs broadcast push) actually receive them. Without this, every push failed with `no channel IDs registered for  or ` (empty tricode lookups).
- Injects `lastPlayType` into `gameData` in the game processor alongside `gameState`. The value comes from the play-by-play `lastPlay.TypeDescKey`, not MoneyPuck CSV — previously the formatter's `lastEvent` string was always blank and the log spammed `column 'lastPlayType' not found in CSV data`.
- Fixes `schedule-team` Makefile target to work alongside `make live`: adds `--profile scheduler` (podman-compose does not auto-activate profiles), `--no-deps` (so it doesn't restart the running backend/cloudtasks-emulator and hit `proxy already running`), and `--build` (so a stale cached scheduler image doesn't mask source changes — surfaced when PRE-state support didn't appear despite already being in source).

## Test plan
- [x] `go test ./...` from `watchgameupdates/` passes
- [ ] `make stop && make live` succeeds, backend startup log shows the enriched data flow
- [ ] `make schedule-team TEAM=COL` against a running `make live` stack succeeds without `missing services [scheduler]` and without `proxy already running`
- [ ] During a real game, watcher logs no longer print `Required data key 'homeTeamAbbrev' not found` or `WARN: no channel ID for home team ,`

🤖 Generated with [Claude Code](https://claude.com/claude-code)