### PR TITLE
feat(notification): select APNs channel set by environment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ LIVEACTIVITY_PUSH_ENABLED=
 APNS_TEAM_ID=                # 10-char Apple Developer Team ID
 APNS_KEY_ID=                 # .p8 key ID from App Store Connect
 APNS_AUTH_KEY=               # base64-encoded .p8 file contents
-APNS_TOPIC=                  # bundle ID, e.g. me.blakenelson.firepower
+APNS_TOPIC=                  # bundle ID, e.g. com.blakenelson.Firepower
 APNS_HOST=                   # api.sandbox.push.apple.com or api.push.apple.com
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 
 TEAM ?= COL
 
-.PHONY: help live emulator stop logs schedule schedule-test watch schedule-team redis-up redis-test redis-schedule redis-schedule-test redis-schedule-team redis-stop redis-logs build-enqueue
+.PHONY: help live live-dev emulator stop logs schedule schedule-test watch schedule-team redis-up redis-test redis-schedule redis-schedule-test redis-schedule-team redis-stop redis-logs build-enqueue
 
 BLUE  := \033[0;34m
 GREEN := \033[0;32m
@@ -35,6 +35,13 @@ help: ## Show available targets
 live: ## Start handler and tasks queue with live game data APIs (.env.home)
 	@podman-compose -f docker-compose.yml -f docker-compose.live.yml up --build -d
 	@printf "$(GREEN)[OK]$(NC) Started\n"
+	@printf "  Backend:        http://localhost:8080\n"
+	@printf "  Tasks emulator: http://localhost:8123\n"
+	@printf "View logs: make logs  |  Stop: make stop\n"
+
+live-dev: ## Start with live game data APIs but use development APNs channel IDs (.env.home + dev channels)
+	@podman-compose -f docker-compose.yml -f docker-compose.live.yml -f docker-compose.dev-channels.yml up --build -d
+	@printf "$(GREEN)[OK]$(NC) Started (development APNs channels)\n"
 	@printf "  Backend:        http://localhost:8080\n"
 	@printf "  Tasks emulator: http://localhost:8123\n"
 	@printf "View logs: make logs  |  Stop: make stop\n"

--- a/docker-compose.dev-channels.yml
+++ b/docker-compose.dev-channels.yml
@@ -1,0 +1,10 @@
+# Compose override: use development APNs channel IDs with the live data stack.
+# Usage: make live-dev
+# Equivalent to .env.home but forces APNS_CHANNEL_ENV=development regardless of
+# what is set in the env file. Useful when testing APNs push against a real game
+# with a debug/simulator iOS build.
+services:
+  backend:
+    environment:
+      - APNS_CHANNEL_ENV=development
+      - APNS_HOST=api.sandbox.push.apple.com

--- a/watchgameupdates/internal/notification/liveactivity/channels.go
+++ b/watchgameupdates/internal/notification/liveactivity/channels.go
@@ -1,12 +1,9 @@
 package liveactivity
 
-// teamChannels maps NHL team tricodes to their Apple-assigned APNs broadcast
-// channel IDs. Generate a channel ID from the iOS app for each team, then
-// paste the value next to the corresponding tricode.
-//
-// Teams with an empty string are skipped silently at push time — the backend
-// will still push to the other team in the game if its channel ID is populated.
-var teamChannels = map[string]string{
+// debugChannels maps NHL team tricodes to APNs broadcast channel IDs created in
+// the Development environment (App Store Connect → Push Notifications → Broadcast → Development).
+// Use these with sandbox APNs and debug/simulator builds.
+var debugChannels = map[string]string{
 	"ANA": "PHP5yU/pEfEAAMK1EJkzxg==",
 	"BOS": "",
 	"BUF": "iqg6AFASEfEAAL4dEtalNQ==",
@@ -21,7 +18,7 @@ var teamChannels = map[string]string{
 	"FLA": "",
 	"LAK": "",
 	"MIN": "",
-	"MTL": "",
+	"MTL": "uj76s1ikEfEAAObg6VLmpQ==",
 	"NJD": "",
 	"NSH": "",
 	"NYI": "",
@@ -36,15 +33,57 @@ var teamChannels = map[string]string{
 	"TOR": "",
 	"UTA": "",
 	"VAN": "",
-	"VGK": "",
+	"VGK": "CVEIvlilEfEAAK6J2RjHtg==",
+	"WPG": "",
+	"WSH": "",
+}
+
+// prodChannels maps NHL team tricodes to APNs broadcast channel IDs created in
+// the Production environment (App Store Connect → Push Notifications → Broadcast → Production).
+// Use these with production APNs and App Store / TestFlight builds.
+var prodChannels = map[string]string{
+	"ANA": "",
+	"BOS": "",
+	"BUF": "",
+	"CAR": "d4E+F1ikEfEAAF7OhT1omw==",
+	"CBJ": "",
+	"CGY": "",
+	"CHI": "",
+	"COL": "S7cBYlilEfEAADY6cc28lw==",
+	"DAL": "",
+	"DET": "",
+	"EDM": "",
+	"FLA": "",
+	"LAK": "",
+	"MIN": "",
+	"MTL": "GOmex1ilEfEAAOYo81Crcg==",
+	"NJD": "",
+	"NSH": "",
+	"NYI": "",
+	"NYR": "",
+	"OTT": "",
+	"PHI": "",
+	"PIT": "",
+	"SEA": "",
+	"SJS": "",
+	"STL": "",
+	"TBL": "",
+	"TOR": "",
+	"UTA": "",
+	"VAN": "",
+	"VGK": "Y8GZXlikEfEAAE4quYgbSQ==",
 	"WPG": "",
 	"WSH": "",
 }
 
 // channelForTeam looks up the APNs broadcast channel ID for a tricode.
-// Returns ("", false) if the team is unknown or its channel ID is not yet populated.
-func channelForTeam(tricode string) (string, bool) {
-	id, known := teamChannels[tricode]
+// Returns ("", false) if the team is unknown or its channel ID is not populated.
+func channelForTeam(tricode string, useDevChannels bool) (string, bool) {
+	m := prodChannels
+	if useDevChannels {
+		m = debugChannels
+	}
+	id, known := m[tricode]
 	if !known || id == "" {
 		return "", false
 	}

--- a/watchgameupdates/internal/notification/liveactivity/config.go
+++ b/watchgameupdates/internal/notification/liveactivity/config.go
@@ -8,11 +8,12 @@ import (
 
 // Config holds APNs credentials for Live Activity broadcast push.
 type Config struct {
-	TeamID  string // 10-char Apple Developer Team ID
-	KeyID   string // .p8 key ID from App Store Connect
-	AuthKey string // contents of .p8 file (not a path, container-friendly)
-	Topic   string // bundle ID, e.g. me.blakenelson.firepower
-	Host    string // api.push.apple.com or api.sandbox.push.apple.com
+	TeamID         string // 10-char Apple Developer Team ID
+	KeyID          string // .p8 key ID from App Store Connect
+	AuthKey        string // contents of .p8 file (not a path, container-friendly)
+	Topic          string // bundle ID, e.g. com.blakenelson.Firepower
+	Host           string // api.push.apple.com or api.sandbox.push.apple.com
+	UseDevChannels bool   // true → use debugChannels (development APNs env); set via APNS_CHANNEL_ENV=development
 }
 
 func LoadConfig() (*Config, error) {
@@ -38,10 +39,11 @@ func LoadConfig() (*Config, error) {
 	}
 
 	return &Config{
-		TeamID:  vars["APNS_TEAM_ID"],
-		KeyID:   vars["APNS_KEY_ID"],
-		AuthKey: vars["APNS_AUTH_KEY"],
-		Topic:   vars["APNS_TOPIC"],
-		Host:    host,
+		TeamID:         vars["APNS_TEAM_ID"],
+		KeyID:          vars["APNS_KEY_ID"],
+		AuthKey:        vars["APNS_AUTH_KEY"],
+		Topic:          vars["APNS_TOPIC"],
+		Host:           host,
+		UseDevChannels: strings.EqualFold(os.Getenv("APNS_CHANNEL_ENV"), "development"),
 	}, nil
 }

--- a/watchgameupdates/internal/notification/liveactivity/formatter.go
+++ b/watchgameupdates/internal/notification/liveactivity/formatter.go
@@ -75,7 +75,7 @@ type apnsPayload struct {
 }
 
 // BuildDispatchMessage produces the JSON string for FormatMessage.
-func BuildDispatchMessage(req NotificationRequest) (string, error) {
+func BuildDispatchMessage(req NotificationRequest, useDevChannels bool) (string, error) {
 	cs, err := buildContentState(req)
 	if err != nil {
 		return "", err
@@ -107,7 +107,7 @@ func BuildDispatchMessage(req NotificationRequest) (string, error) {
 	homeAbbrev := strings.ToUpper(req.Data["homeTeamAbbrev"])
 	awayAbbrev := strings.ToUpper(req.Data["awayTeamAbbrev"])
 
-	channels := channelsForTeams(homeAbbrev, awayAbbrev)
+	channels := channelsForTeams(homeAbbrev, awayAbbrev, useDevChannels)
 	if len(channels) == 0 {
 		return "", fmt.Errorf("no channel IDs registered for %s or %s", homeAbbrev, awayAbbrev)
 	}
@@ -185,15 +185,15 @@ func formatLastEvent(playType string) string {
 
 // channelsForTeams returns the APNs broadcast channel IDs for the two teams.
 // Teams whose channel ID has not been populated in channels.go are skipped.
-func channelsForTeams(homeAbbrev, awayAbbrev string) []string {
+func channelsForTeams(homeAbbrev, awayAbbrev string, useDevChannels bool) []string {
 	var channels []string
-	if id, ok := channelForTeam(homeAbbrev); ok {
+	if id, ok := channelForTeam(homeAbbrev, useDevChannels); ok {
 		channels = append(channels, id)
 	} else {
 		log.Printf("WARN: no channel ID for home team %s, skipping", homeAbbrev)
 	}
 	if awayAbbrev != "" && awayAbbrev != homeAbbrev {
-		if id, ok := channelForTeam(awayAbbrev); ok {
+		if id, ok := channelForTeam(awayAbbrev, useDevChannels); ok {
 			channels = append(channels, id)
 		} else {
 			log.Printf("WARN: no channel ID for away team %s, skipping", awayAbbrev)

--- a/watchgameupdates/internal/notification/liveactivity/formatter_test.go
+++ b/watchgameupdates/internal/notification/liveactivity/formatter_test.go
@@ -8,21 +8,25 @@ import (
 	. "watchgameupdates/internal/notification"
 )
 
-// withChannels temporarily sets channel IDs in teamChannels for the duration of fn,
-// then restores the originals. Allows tests to exercise the lookup without mutating
-// the real map permanently.
-func withChannels(t *testing.T, ids map[string]string, fn func()) {
+// withChannels temporarily sets channel IDs in the prod or dev map for the duration
+// of fn, then restores the originals. Allows tests to exercise channel lookup without
+// mutating the real maps permanently.
+func withChannels(t *testing.T, ids map[string]string, useDevChannels bool, fn func()) {
 	t.Helper()
+	m := prodChannels
+	if useDevChannels {
+		m = debugChannels
+	}
 	orig := map[string]string{}
-	for k, v := range teamChannels {
+	for k, v := range m {
 		orig[k] = v
 	}
 	for k, v := range ids {
-		teamChannels[k] = v
+		m[k] = v
 	}
 	t.Cleanup(func() {
 		for k, v := range orig {
-			teamChannels[k] = v
+			m[k] = v
 		}
 	})
 	fn()
@@ -46,8 +50,8 @@ func baseReq() NotificationRequest {
 }
 
 func TestBuildDispatchMessage_HappyPath(t *testing.T) {
-	withChannels(t, map[string]string{"BOS": "chan-BOS", "NYR": "chan-NYR"}, func() {
-		msg, err := BuildDispatchMessage(baseReq())
+	withChannels(t, map[string]string{"BOS": "chan-BOS", "NYR": "chan-NYR"}, false, func() {
+		msg, err := BuildDispatchMessage(baseReq(), false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -95,12 +99,12 @@ func TestBuildDispatchMessage_HappyPath(t *testing.T) {
 }
 
 func TestBuildDispatchMessage_GameEnded(t *testing.T) {
-	withChannels(t, map[string]string{"BOS": "chan-BOS", "NYR": "chan-NYR"}, func() {
+	withChannels(t, map[string]string{"BOS": "chan-BOS", "NYR": "chan-NYR"}, false, func() {
 		req := baseReq()
 		req.Data["gameState"] = "Final"
 		req.Data["lastPlayType"] = "game-end"
 
-		msg, err := BuildDispatchMessage(req)
+		msg, err := BuildDispatchMessage(req, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -124,11 +128,11 @@ func TestBuildDispatchMessage_GameEnded(t *testing.T) {
 }
 
 func TestBuildDispatchMessage_NilEventString(t *testing.T) {
-	withChannels(t, map[string]string{"BOS": "chan-BOS", "NYR": "chan-NYR"}, func() {
+	withChannels(t, map[string]string{"BOS": "chan-BOS", "NYR": "chan-NYR"}, false, func() {
 		req := baseReq()
 		delete(req.Data, "lastPlayType")
 
-		msg, err := BuildDispatchMessage(req)
+		msg, err := BuildDispatchMessage(req, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -147,7 +151,7 @@ func TestBuildDispatchMessage_NilEventString(t *testing.T) {
 
 func TestBuildDispatchMessage_NoChannelsRegistered(t *testing.T) {
 	// Both teams have empty channel IDs — should error rather than push to nothing.
-	_, err := BuildDispatchMessage(baseReq())
+	_, err := BuildDispatchMessage(baseReq(), false)
 	if err == nil {
 		t.Fatal("want error when no channel IDs are registered, got nil")
 	}
@@ -155,8 +159,8 @@ func TestBuildDispatchMessage_NoChannelsRegistered(t *testing.T) {
 
 func TestBuildDispatchMessage_OneChannelRegistered(t *testing.T) {
 	// Only home team has a channel ID — push to that one, skip away.
-	withChannels(t, map[string]string{"BOS": "chan-BOS"}, func() {
-		msg, err := BuildDispatchMessage(baseReq())
+	withChannels(t, map[string]string{"BOS": "chan-BOS"}, false, func() {
+		msg, err := BuildDispatchMessage(baseReq(), false)
 		if err != nil {
 			t.Fatalf("unexpected error when one channel registered: %v", err)
 		}
@@ -174,12 +178,12 @@ func TestBuildDispatchMessage_OneChannelRegistered(t *testing.T) {
 }
 
 func TestBuildDispatchMessage_MissingScores(t *testing.T) {
-	withChannels(t, map[string]string{"BOS": "chan-BOS", "NYR": "chan-NYR"}, func() {
+	withChannels(t, map[string]string{"BOS": "chan-BOS", "NYR": "chan-NYR"}, false, func() {
 		req := baseReq()
 		delete(req.Data, "homeTeamGoals")
 		delete(req.Data, "awayTeamGoals")
 
-		msg, err := BuildDispatchMessage(req)
+		msg, err := BuildDispatchMessage(req, false)
 		if err != nil {
 			t.Fatalf("missing scores should not error: %v", err)
 		}
@@ -260,8 +264,8 @@ func TestFormatLastEvent(t *testing.T) {
 }
 
 func TestChannelsForTeams_BothRegistered(t *testing.T) {
-	withChannels(t, map[string]string{"BOS": "chan-BOS", "NYR": "chan-NYR"}, func() {
-		ch := channelsForTeams("BOS", "NYR")
+	withChannels(t, map[string]string{"BOS": "chan-BOS", "NYR": "chan-NYR"}, false, func() {
+		ch := channelsForTeams("BOS", "NYR", false)
 		if len(ch) != 2 {
 			t.Fatalf("want 2 channels, got %d", len(ch))
 		}
@@ -272,15 +276,15 @@ func TestChannelsForTeams_BothRegistered(t *testing.T) {
 }
 
 func TestChannelsForTeams_NoneRegistered(t *testing.T) {
-	ch := channelsForTeams("BOS", "NYR")
+	ch := channelsForTeams("BOS", "NYR", false)
 	if len(ch) != 0 {
 		t.Errorf("want 0 channels when none registered, got %d", len(ch))
 	}
 }
 
 func TestChannelsForTeams_SameTeam(t *testing.T) {
-	withChannels(t, map[string]string{"BOS": "chan-BOS"}, func() {
-		ch := channelsForTeams("BOS", "BOS")
+	withChannels(t, map[string]string{"BOS": "chan-BOS"}, false, func() {
+		ch := channelsForTeams("BOS", "BOS", false)
 		if len(ch) != 1 {
 			t.Errorf("same-team edge case: want 1 channel, got %d", len(ch))
 		}

--- a/watchgameupdates/internal/notification/liveactivity/notifier.go
+++ b/watchgameupdates/internal/notification/liveactivity/notifier.go
@@ -39,7 +39,8 @@ var requiredDataKeys = []string{
 
 // LiveActivityNotifier implements notification.Notifier.
 type LiveActivityNotifier struct {
-	client *apnsClient
+	client         *apnsClient
+	useDevChannels bool
 }
 
 // New creates a LiveActivityNotifier from environment config.
@@ -55,8 +56,12 @@ func New() (*LiveActivityNotifier, error) {
 		return nil, fmt.Errorf("create APNs client: %w", err)
 	}
 
-	log.Printf("LiveActivity notifier initialized: host=%s topic=%s", cfg.Host, cfg.Topic)
-	return &LiveActivityNotifier{client: client}, nil
+	channelEnv := "production"
+	if cfg.UseDevChannels {
+		channelEnv = "development"
+	}
+	log.Printf("LiveActivity notifier initialized: host=%s topic=%s channels=%s", cfg.Host, cfg.Topic, channelEnv)
+	return &LiveActivityNotifier{client: client, useDevChannels: cfg.UseDevChannels}, nil
 }
 
 func (n *LiveActivityNotifier) GetRequiredDataKeys() []string {
@@ -65,7 +70,7 @@ func (n *LiveActivityNotifier) GetRequiredDataKeys() []string {
 
 // FormatMessage builds the dispatch envelope (channels + APNs payload) as JSON.
 func (n *LiveActivityNotifier) FormatMessage(req NotificationRequest) string {
-	msg, err := BuildDispatchMessage(req)
+	msg, err := BuildDispatchMessage(req, n.useDevChannels)
 	if err != nil {
 		log.Printf("ERROR: LiveActivity FormatMessage: %v", err)
 		return ""


### PR DESCRIPTION
## Summary
Adds dev/prod separation for Live Activity APNs broadcast channels. Apple assigns broadcast channel IDs separately per environment (Development vs Production), and a tricode minted in one does not exist in the other — so a single hardcoded map could only ever target one environment.

- Split the single `teamChannels` map into `debugChannels` and `prodChannels`, populated from the iOS app's tricode tables.
- `channelForTeam(tricode, useDevChannels)` selects the map; the choice threads from `Config` → `LiveActivityNotifier` → `BuildDispatchMessage` → `channelsForTeams` so resolution is per-dispatch.
- New `APNS_CHANNEL_ENV` env var: `development` → debug channels, anything else (default) → production channels. Startup log now prints `channels=development|production`.
- Defaults: `.env.home` (live data) → production channels; `.env.local` (emulator) → development channels.
- New `docker-compose.dev-channels.yml` override + `make live-dev` target: run the live-data stack against development channels and the sandbox APNs host (overrides both `APNS_CHANNEL_ENV` and `APNS_HOST`, so the dev-channel/sandbox-host pairing can't drift).
- `CLAUDE.md`: APNs bundle ID example updated to `com.blakenelson.Firepower`.

## Environment matrix
| Command | APNs host | Channels |
|---|---|---|
| `make emulator` | sandbox (.env.local) | development |
| `make live` | per .env.home | production |
| `make live-dev` | sandbox (forced) | development (forced) |

## Test plan
- [x] `go build ./...` and `go test ./...` from `watchgameupdates/` pass
- [ ] `make live` startup log shows `channels=production`
- [ ] `make live-dev` startup log shows `channels=development` and sandbox host
- [ ] A real game pushes to the correct environment's channel IDs without `ChannelNotRegistered`

## Note
Production push requires a production-capable APNs key. The current key in use is sandbox-only (`BadEnvironmentKeyInToken` against `api.push.apple.com`); creating a universal key under App Store Connect → Keys is a config step outside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)