### PR TITLE
feat(liveactivity): replace lastEvent with structured eventType/eventDetail/eventTeam

### DIFF
--- a/watchgameupdates/internal/notification/liveactivity/formatter.go
+++ b/watchgameupdates/internal/notification/liveactivity/formatter.go
@@ -13,15 +13,17 @@ package liveactivity
 //         "stale-date": 1234568890,       // update only: now + 90s
 //         "dismissal-date": 1234569490,   // end only: now + 10min
 //         "content-state": {
-//           "sport":     "nhl",
-//           "homeTeam":  "BOS",
-//           "awayTeam":  "NYR",
-//           "homeScore": 2,
-//           "awayScore": 1,
-//           "homeXG":    2.4,
-//           "awayXG":    1.8,
-//           "gameState": "14:32 left, 2nd period",
-//           "lastEvent": "Goal scored"
+//           "sport":       "nhl",
+//           "homeTeam":    "BOS",
+//           "awayTeam":    "NYR",
+//           "homeScore":   2,
+//           "awayScore":   1,
+//           "homeXG":      2.4,
+//           "awayXG":      1.8,
+//           "gameState":   "14:32 left, 2nd period",
+//           "eventType":   "goal",       // "goal"|"penalty"|"period_end"|"" (empty = no event)
+//           "eventDetail": "",           // scorer name when pipeline lands; empty until then
+//           "eventTeam":   "BOS"         // tricode of team that caused the event
 //         }
 //       }
 //     }
@@ -51,15 +53,17 @@ type dispatchEnvelope struct {
 }
 
 type contentState struct {
-	Sport     string  `json:"sport"`
-	HomeTeam  string  `json:"homeTeam"`
-	AwayTeam  string  `json:"awayTeam"`
-	HomeScore int     `json:"homeScore"`
-	AwayScore int     `json:"awayScore"`
-	HomeXG    float64 `json:"homeXG"`
-	AwayXG    float64 `json:"awayXG"`
-	GameState string  `json:"gameState"`
-	LastEvent string  `json:"lastEvent"`
+	Sport       string  `json:"sport"`
+	HomeTeam    string  `json:"homeTeam"`
+	AwayTeam    string  `json:"awayTeam"`
+	HomeScore   int     `json:"homeScore"`
+	AwayScore   int     `json:"awayScore"`
+	HomeXG      float64 `json:"homeXG"`
+	AwayXG      float64 `json:"awayXG"`
+	GameState   string  `json:"gameState"`
+	EventType   string  `json:"eventType"`   // "goal"|"penalty"|"period_end"|""
+	EventDetail string  `json:"eventDetail"` // scorer name when available; "" until then
+	EventTeam   string  `json:"eventTeam"`   // scoring/penalised team tricode; "" if unknown
 }
 
 type apsEnvelope struct {
@@ -113,7 +117,7 @@ func BuildDispatchMessage(req NotificationRequest, useDevChannels bool) (string,
 	}
 
 	env := dispatchEnvelope{
-		Channels: channels,
+		Channels: channelsForTeams(homeAbbrev, awayAbbrev),
 		Payload:  json.RawMessage(payloadBytes),
 	}
 
@@ -128,20 +132,41 @@ func buildContentState(req NotificationRequest) (contentState, error) {
 	homeScore := parseIntSafe(req.Data["homeTeamGoals"])
 	awayScore := parseIntSafe(req.Data["awayTeamGoals"])
 
+	eventType, eventTeam := classifyEvent(req.Data["lastPlayType"], req.Data)
+
 	return contentState{
-		Sport:     "nhl",
-		HomeTeam:  strings.ToUpper(req.Data["homeTeamAbbrev"]),
-		AwayTeam:  strings.ToUpper(req.Data["awayTeamAbbrev"]),
-		HomeScore: homeScore,
-		AwayScore: awayScore,
-		HomeXG:    safeXG(req.Data["homeTeamExpectedGoals"]),
-		AwayXG:    safeXG(req.Data["awayTeamExpectedGoals"]),
-		GameState: req.Data["gameState"],
-		LastEvent: formatLastEvent(req.Data["lastPlayType"]),
+		Sport:       "nhl",
+		HomeTeam:    strings.ToUpper(req.Data["homeTeamAbbrev"]),
+		AwayTeam:    strings.ToUpper(req.Data["awayTeamAbbrev"]),
+		HomeScore:   homeScore,
+		AwayScore:   awayScore,
+		HomeXG:      safeXG(req.Data["homeTeamExpectedGoals"]),
+		AwayXG:      safeXG(req.Data["awayTeamExpectedGoals"]),
+		GameState:   req.Data["gameState"],
+		EventType:   eventType,
+		EventDetail: "", // scorer name: empty until the play-by-play pipeline lands (TODO)
+		EventTeam:   eventTeam,
 	}, nil
 }
 
-// safeXG parses an xG string, returning 0 for empty, unparseable, NaN, or Inf values.
+// classifyEvent returns (eventType, eventTeam) for the current play.
+// eventDetail (scorer name) is a separate TODO — see planning/todos.md.
+func classifyEvent(playType string, data map[string]string) (eventType, eventTeam string) {
+	switch playType {
+	case "goal":
+		return "goal", strings.ToUpper(data["eventTeamAbbrev"])
+	case "penalty":
+		return "penalty", strings.ToUpper(data["eventTeamAbbrev"])
+	case "period-end":
+		return "period_end", ""
+	case "game-end":
+		return "period_end", ""
+	default:
+		return "", ""
+	}
+}
+
+// safeXG parses an xG string and guards against NaN/Inf (CRITICAL Gap 2B).
 func safeXG(s string) float64 {
 	if s == "" {
 		return 0
@@ -162,26 +187,6 @@ func parseIntSafe(s string) int {
 	return v
 }
 
-// formatLastEvent converts a play TypeDescKey to a human-readable string.
-// Empty or unrecognized types return "" safely.
-func formatLastEvent(playType string) string {
-	switch playType {
-	case "goal":
-		return "Goal scored"
-	case "shot-on-goal":
-		return "Shot on goal"
-	case "blocked-shot":
-		return "Shot blocked"
-	case "missed-shot":
-		return "Shot missed"
-	case "period-end":
-		return "Period ended"
-	case "game-end":
-		return "Final"
-	default:
-		return "" // empty string is safe for the iOS lastEvent optional
-	}
-}
 
 // channelsForTeams returns the APNs broadcast channel IDs for the two teams.
 // Teams whose channel ID has not been populated in channels.go are skipped.

--- a/watchgameupdates/internal/notification/liveactivity/formatter.go
+++ b/watchgameupdates/internal/notification/liveactivity/formatter.go
@@ -5,7 +5,7 @@ package liveactivity
 // FormatMessage output shape (parsed by SendNotification):
 //
 //   {
-//     "channels": ["nhl-team-BOS", "nhl-team-NYR"],
+//     "channels": ["<base64-channel-id-1>", "<base64-channel-id-2>"],
 //     "payload": {
 //       "aps": {
 //         "timestamp":  1234567890,
@@ -79,6 +79,7 @@ type apnsPayload struct {
 }
 
 // BuildDispatchMessage produces the JSON string for FormatMessage.
+// useDevChannels selects sandbox APNs channel IDs (debug builds) vs production.
 func BuildDispatchMessage(req NotificationRequest, useDevChannels bool) (string, error) {
 	cs, err := buildContentState(req)
 	if err != nil {
@@ -117,7 +118,7 @@ func BuildDispatchMessage(req NotificationRequest, useDevChannels bool) (string,
 	}
 
 	env := dispatchEnvelope{
-		Channels: channelsForTeams(homeAbbrev, awayAbbrev),
+		Channels: channels,
 		Payload:  json.RawMessage(payloadBytes),
 	}
 
@@ -166,7 +167,7 @@ func classifyEvent(playType string, data map[string]string) (eventType, eventTea
 	}
 }
 
-// safeXG parses an xG string and guards against NaN/Inf (CRITICAL Gap 2B).
+// safeXG parses an xG string and guards against NaN/Inf.
 func safeXG(s string) float64 {
 	if s == "" {
 		return 0
@@ -186,7 +187,6 @@ func parseIntSafe(s string) int {
 	}
 	return v
 }
-
 
 // channelsForTeams returns the APNs broadcast channel IDs for the two teams.
 // Teams whose channel ID has not been populated in channels.go are skipped.

--- a/watchgameupdates/internal/notification/liveactivity/formatter_test.go
+++ b/watchgameupdates/internal/notification/liveactivity/formatter_test.go
@@ -45,6 +45,7 @@ func baseReq() NotificationRequest {
 			"awayTeamAbbrev":        "NYR",
 			"gameState":             "14:32 left, 2nd period",
 			"lastPlayType":          "goal",
+			"eventTeamAbbrev":       "BOS",
 		},
 	}
 }
@@ -56,25 +57,25 @@ func TestBuildDispatchMessage_HappyPath(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		var env dispatchEnvelope
-		if err := json.Unmarshal([]byte(msg), &env); err != nil {
-			t.Fatalf("output is not valid JSON: %v", err)
-		}
+	var env dispatchEnvelope
+	if err := json.Unmarshal([]byte(msg), &env); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
 
-		if len(env.Channels) != 2 {
-			t.Errorf("want 2 channels, got %d", len(env.Channels))
-		}
-		if env.Channels[0] != "chan-BOS" {
-			t.Errorf("want chan-BOS, got %s", env.Channels[0])
-		}
-		if env.Channels[1] != "chan-NYR" {
-			t.Errorf("want chan-NYR, got %s", env.Channels[1])
-		}
+	if len(env.Channels) != 2 {
+		t.Errorf("want 2 channels, got %d", len(env.Channels))
+	}
+	if env.Channels[0] != "nhl-team-BOS" {
+		t.Errorf("want nhl-team-BOS, got %s", env.Channels[0])
+	}
+	if env.Channels[1] != "nhl-team-NYR" {
+		t.Errorf("want nhl-team-NYR, got %s", env.Channels[1])
+	}
 
-		var payload apnsPayload
-		if err := json.Unmarshal(env.Payload, &payload); err != nil {
-			t.Fatalf("payload not valid JSON: %v", err)
-		}
+	var payload apnsPayload
+	if err := json.Unmarshal(env.Payload, &payload); err != nil {
+		t.Fatalf("payload not valid JSON: %v", err)
+	}
 
 		cs := payload.APS.ContentState
 		if cs.HomeScore != 2 {
@@ -165,16 +166,20 @@ func TestBuildDispatchMessage_OneChannelRegistered(t *testing.T) {
 			t.Fatalf("unexpected error when one channel registered: %v", err)
 		}
 
-		var env dispatchEnvelope
-		json.Unmarshal([]byte(msg), &env)
+func TestBuildDispatchMessage_GoalEventFields(t *testing.T) {
+	msg, _ := BuildDispatchMessage(baseReq())
+	cs := unmarshalCS(t, msg)
 
-		if len(env.Channels) != 1 {
-			t.Errorf("want 1 channel, got %d", len(env.Channels))
-		}
-		if env.Channels[0] != "chan-BOS" {
-			t.Errorf("want chan-BOS, got %s", env.Channels[0])
-		}
-	})
+	if cs.EventType != "goal" {
+		t.Errorf("want eventType=goal, got %q", cs.EventType)
+	}
+	if cs.EventTeam != "BOS" {
+		t.Errorf("want eventTeam=BOS, got %q", cs.EventTeam)
+	}
+	// eventDetail empty until scorer pipeline lands
+	if cs.EventDetail != "" {
+		t.Errorf("want eventDetail empty, got %q", cs.EventDetail)
+	}
 }
 
 func TestBuildDispatchMessage_MissingScores(t *testing.T) {
@@ -200,6 +205,94 @@ func TestBuildDispatchMessage_MissingScores(t *testing.T) {
 		}
 	})
 }
+
+func TestBuildDispatchMessage_MissingPlayType_EmptyEvent(t *testing.T) {
+	req := baseReq()
+	delete(req.Data, "lastPlayType")
+	cs := unmarshalCS(t, mustBuild(t, req))
+
+	if cs.EventType != "" {
+		t.Errorf("want empty eventType for missing playType, got %q", cs.EventType)
+	}
+	if cs.EventTeam != "" {
+		t.Errorf("want empty eventTeam for missing playType, got %q", cs.EventTeam)
+	}
+}
+
+func TestBuildDispatchMessage_UnknownPlayType_EmptyEvent(t *testing.T) {
+	req := baseReq()
+	req.Data["lastPlayType"] = "faceoff"
+	cs := unmarshalCS(t, mustBuild(t, req))
+
+	if cs.EventType != "" {
+		t.Errorf("faceoff should produce empty eventType, got %q", cs.EventType)
+	}
+}
+
+func TestBuildDispatchMessage_GameEnded(t *testing.T) {
+	req := baseReq()
+	req.Data["gameState"] = "Final"
+	req.Data["lastPlayType"] = "game-end"
+
+	msg, err := BuildDispatchMessage(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var env dispatchEnvelope
+	json.Unmarshal([]byte(msg), &env)
+
+	var payload apnsPayload
+	json.Unmarshal(env.Payload, &payload)
+
+	if payload.APS.Event != "end" {
+		t.Errorf("want event=end for game-end, got %s", payload.APS.Event)
+	}
+	if payload.APS.DismissalDate == nil {
+		t.Error("want non-nil dismissal-date for game-end")
+	}
+	if payload.APS.StaleDate != nil {
+		t.Error("want nil stale-date for game-end")
+	}
+}
+
+// classifyEvent unit tests
+
+func TestClassifyEvent_Goal(t *testing.T) {
+	et, team := classifyEvent("goal", map[string]string{"eventTeamAbbrev": "bos"})
+	if et != "goal" {
+		t.Errorf("want goal, got %q", et)
+	}
+	if team != "BOS" {
+		t.Errorf("want BOS (uppercased), got %q", team)
+	}
+}
+
+func TestClassifyEvent_PeriodEnd(t *testing.T) {
+	et, team := classifyEvent("period-end", nil)
+	if et != "period_end" {
+		t.Errorf("want period_end, got %q", et)
+	}
+	if team != "" {
+		t.Errorf("want empty team for period-end, got %q", team)
+	}
+}
+
+func TestClassifyEvent_GameEnd(t *testing.T) {
+	et, _ := classifyEvent("game-end", nil)
+	if et != "period_end" {
+		t.Errorf("game-end should map to period_end, got %q", et)
+	}
+}
+
+func TestClassifyEvent_Unknown(t *testing.T) {
+	et, team := classifyEvent("blocked-shot", map[string]string{})
+	if et != "" || team != "" {
+		t.Errorf("unknown play should produce empty fields, got type=%q team=%q", et, team)
+	}
+}
+
+// Existing tests preserved
 
 func TestSafeXG_NaN(t *testing.T) {
 	if got := safeXG("NaN"); got != 0 {
@@ -238,28 +331,13 @@ func TestSafeXG_ActualNaN(t *testing.T) {
 	}
 }
 
-func TestFormatLastEvent(t *testing.T) {
-	cases := []struct {
-		input string
-		want  string
-	}{
-		{"goal", "Goal scored"},
-		{"shot-on-goal", "Shot on goal"},
-		{"blocked-shot", "Shot blocked"},
-		{"missed-shot", "Shot missed"},
-		{"period-end", "Period ended"},
-		{"game-end", "Final"},
-		{"", ""},
-		{"faceoff", ""},
-		{"unknown-type", ""},
-	}
-	for _, tc := range cases {
-		t.Run(tc.input, func(t *testing.T) {
-			got := formatLastEvent(tc.input)
-			if got != tc.want {
-				t.Errorf("formatLastEvent(%q) = %q, want %q", tc.input, got, tc.want)
-			}
-		})
+func TestBuildDispatchMessage_MissingScores(t *testing.T) {
+	req := baseReq()
+	delete(req.Data, "homeTeamGoals")
+	delete(req.Data, "awayTeamGoals")
+	cs := unmarshalCS(t, mustBuild(t, req))
+	if cs.HomeScore != 0 || cs.AwayScore != 0 {
+		t.Errorf("missing scores should default to 0, got home=%d away=%d", cs.HomeScore, cs.AwayScore)
 	}
 }
 

--- a/watchgameupdates/internal/notification/liveactivity/formatter_test.go
+++ b/watchgameupdates/internal/notification/liveactivity/formatter_test.go
@@ -57,25 +57,25 @@ func TestBuildDispatchMessage_HappyPath(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-	var env dispatchEnvelope
-	if err := json.Unmarshal([]byte(msg), &env); err != nil {
-		t.Fatalf("output is not valid JSON: %v", err)
-	}
+		var env dispatchEnvelope
+		if err := json.Unmarshal([]byte(msg), &env); err != nil {
+			t.Fatalf("output is not valid JSON: %v", err)
+		}
 
-	if len(env.Channels) != 2 {
-		t.Errorf("want 2 channels, got %d", len(env.Channels))
-	}
-	if env.Channels[0] != "nhl-team-BOS" {
-		t.Errorf("want nhl-team-BOS, got %s", env.Channels[0])
-	}
-	if env.Channels[1] != "nhl-team-NYR" {
-		t.Errorf("want nhl-team-NYR, got %s", env.Channels[1])
-	}
+		if len(env.Channels) != 2 {
+			t.Errorf("want 2 channels, got %d", len(env.Channels))
+		}
+		if env.Channels[0] != "chan-BOS" {
+			t.Errorf("want chan-BOS, got %s", env.Channels[0])
+		}
+		if env.Channels[1] != "chan-NYR" {
+			t.Errorf("want chan-NYR, got %s", env.Channels[1])
+		}
 
-	var payload apnsPayload
-	if err := json.Unmarshal(env.Payload, &payload); err != nil {
-		t.Fatalf("payload not valid JSON: %v", err)
-	}
+		var payload apnsPayload
+		if err := json.Unmarshal(env.Payload, &payload); err != nil {
+			t.Fatalf("payload not valid JSON: %v", err)
+		}
 
 		cs := payload.APS.ContentState
 		if cs.HomeScore != 2 {
@@ -95,6 +95,67 @@ func TestBuildDispatchMessage_HappyPath(t *testing.T) {
 		}
 		if payload.APS.StaleDate == nil {
 			t.Error("want non-nil stale-date for in-progress game")
+		}
+	})
+}
+
+// New event fields tests
+
+func TestBuildDispatchMessage_GoalEventFields(t *testing.T) {
+	withChannels(t, map[string]string{"BOS": "chan-BOS", "NYR": "chan-NYR"}, false, func() {
+		cs := unmarshalCS(t, mustBuild(t, baseReq(), false))
+
+		if cs.EventType != "goal" {
+			t.Errorf("want eventType=goal, got %q", cs.EventType)
+		}
+		if cs.EventTeam != "BOS" {
+			t.Errorf("want eventTeam=BOS, got %q", cs.EventTeam)
+		}
+		if cs.EventDetail != "" {
+			t.Errorf("want eventDetail empty, got %q", cs.EventDetail)
+		}
+	})
+}
+
+func TestBuildDispatchMessage_PenaltyEvent(t *testing.T) {
+	withChannels(t, map[string]string{"BOS": "chan-BOS", "NYR": "chan-NYR"}, false, func() {
+		req := baseReq()
+		req.Data["lastPlayType"] = "penalty"
+		req.Data["eventTeamAbbrev"] = "NYR"
+		cs := unmarshalCS(t, mustBuild(t, req, false))
+
+		if cs.EventType != "penalty" {
+			t.Errorf("want eventType=penalty, got %q", cs.EventType)
+		}
+		if cs.EventTeam != "NYR" {
+			t.Errorf("want eventTeam=NYR, got %q", cs.EventTeam)
+		}
+	})
+}
+
+func TestBuildDispatchMessage_MissingPlayType_EmptyEvent(t *testing.T) {
+	withChannels(t, map[string]string{"BOS": "chan-BOS", "NYR": "chan-NYR"}, false, func() {
+		req := baseReq()
+		delete(req.Data, "lastPlayType")
+		cs := unmarshalCS(t, mustBuild(t, req, false))
+
+		if cs.EventType != "" {
+			t.Errorf("want empty eventType for missing playType, got %q", cs.EventType)
+		}
+		if cs.EventTeam != "" {
+			t.Errorf("want empty eventTeam for missing playType, got %q", cs.EventTeam)
+		}
+	})
+}
+
+func TestBuildDispatchMessage_UnknownPlayType_EmptyEvent(t *testing.T) {
+	withChannels(t, map[string]string{"BOS": "chan-BOS", "NYR": "chan-NYR"}, false, func() {
+		req := baseReq()
+		req.Data["lastPlayType"] = "faceoff"
+		cs := unmarshalCS(t, mustBuild(t, req, false))
+
+		if cs.EventType != "" {
+			t.Errorf("faceoff should produce empty eventType, got %q", cs.EventType)
 		}
 	})
 }
@@ -128,28 +189,6 @@ func TestBuildDispatchMessage_GameEnded(t *testing.T) {
 	})
 }
 
-func TestBuildDispatchMessage_NilEventString(t *testing.T) {
-	withChannels(t, map[string]string{"BOS": "chan-BOS", "NYR": "chan-NYR"}, false, func() {
-		req := baseReq()
-		delete(req.Data, "lastPlayType")
-
-		msg, err := BuildDispatchMessage(req, false)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		var env dispatchEnvelope
-		json.Unmarshal([]byte(msg), &env)
-
-		var payload apnsPayload
-		json.Unmarshal(env.Payload, &payload)
-
-		if payload.APS.ContentState.LastEvent != "" {
-			t.Errorf("want empty lastEvent for missing playType, got %q", payload.APS.ContentState.LastEvent)
-		}
-	})
-}
-
 func TestBuildDispatchMessage_NoChannelsRegistered(t *testing.T) {
 	// Both teams have empty channel IDs — should error rather than push to nothing.
 	_, err := BuildDispatchMessage(baseReq(), false)
@@ -159,101 +198,36 @@ func TestBuildDispatchMessage_NoChannelsRegistered(t *testing.T) {
 }
 
 func TestBuildDispatchMessage_OneChannelRegistered(t *testing.T) {
-	// Only home team has a channel ID — push to that one, skip away.
 	withChannels(t, map[string]string{"BOS": "chan-BOS"}, false, func() {
 		msg, err := BuildDispatchMessage(baseReq(), false)
 		if err != nil {
 			t.Fatalf("unexpected error when one channel registered: %v", err)
 		}
 
-func TestBuildDispatchMessage_GoalEventFields(t *testing.T) {
-	msg, _ := BuildDispatchMessage(baseReq())
-	cs := unmarshalCS(t, msg)
-
-	if cs.EventType != "goal" {
-		t.Errorf("want eventType=goal, got %q", cs.EventType)
-	}
-	if cs.EventTeam != "BOS" {
-		t.Errorf("want eventTeam=BOS, got %q", cs.EventTeam)
-	}
-	// eventDetail empty until scorer pipeline lands
-	if cs.EventDetail != "" {
-		t.Errorf("want eventDetail empty, got %q", cs.EventDetail)
-	}
-}
-
-func TestBuildDispatchMessage_MissingScores(t *testing.T) {
-	withChannels(t, map[string]string{"BOS": "chan-BOS", "NYR": "chan-NYR"}, false, func() {
-		req := baseReq()
-		delete(req.Data, "homeTeamGoals")
-		delete(req.Data, "awayTeamGoals")
-
-		msg, err := BuildDispatchMessage(req, false)
-		if err != nil {
-			t.Fatalf("missing scores should not error: %v", err)
-		}
-
 		var env dispatchEnvelope
 		json.Unmarshal([]byte(msg), &env)
 
-		var payload apnsPayload
-		json.Unmarshal(env.Payload, &payload)
-
-		cs := payload.APS.ContentState
-		if cs.HomeScore != 0 || cs.AwayScore != 0 {
-			t.Errorf("missing scores should default to 0, got home=%d away=%d", cs.HomeScore, cs.AwayScore)
+		if len(env.Channels) != 1 {
+			t.Errorf("want 1 channel, got %d", len(env.Channels))
+		}
+		if env.Channels[0] != "chan-BOS" {
+			t.Errorf("want chan-BOS, got %s", env.Channels[0])
 		}
 	})
 }
 
-func TestBuildDispatchMessage_MissingPlayType_EmptyEvent(t *testing.T) {
-	req := baseReq()
-	delete(req.Data, "lastPlayType")
-	cs := unmarshalCS(t, mustBuild(t, req))
-
-	if cs.EventType != "" {
-		t.Errorf("want empty eventType for missing playType, got %q", cs.EventType)
-	}
-	if cs.EventTeam != "" {
-		t.Errorf("want empty eventTeam for missing playType, got %q", cs.EventTeam)
-	}
-}
-
-func TestBuildDispatchMessage_UnknownPlayType_EmptyEvent(t *testing.T) {
-	req := baseReq()
-	req.Data["lastPlayType"] = "faceoff"
-	cs := unmarshalCS(t, mustBuild(t, req))
-
-	if cs.EventType != "" {
-		t.Errorf("faceoff should produce empty eventType, got %q", cs.EventType)
-	}
-}
-
-func TestBuildDispatchMessage_GameEnded(t *testing.T) {
-	req := baseReq()
-	req.Data["gameState"] = "Final"
-	req.Data["lastPlayType"] = "game-end"
-
-	msg, err := BuildDispatchMessage(req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	var env dispatchEnvelope
-	json.Unmarshal([]byte(msg), &env)
-
-	var payload apnsPayload
-	json.Unmarshal(env.Payload, &payload)
-
-	if payload.APS.Event != "end" {
-		t.Errorf("want event=end for game-end, got %s", payload.APS.Event)
-	}
-	if payload.APS.DismissalDate == nil {
-		t.Error("want non-nil dismissal-date for game-end")
-	}
-	if payload.APS.StaleDate != nil {
-		t.Error("want nil stale-date for game-end")
-	}
+func TestBuildDispatchMessage_DevChannels(t *testing.T) {
+	withChannels(t, map[string]string{"BOS": "dev-chan-BOS"}, true, func() {
+		msg, err := BuildDispatchMessage(baseReq(), true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var env dispatchEnvelope
+		json.Unmarshal([]byte(msg), &env)
+		if len(env.Channels) < 1 || env.Channels[0] != "dev-chan-BOS" {
+			t.Errorf("want dev-chan-BOS, got %v", env.Channels)
+		}
+	})
 }
 
 // classifyEvent unit tests
@@ -332,13 +306,15 @@ func TestSafeXG_ActualNaN(t *testing.T) {
 }
 
 func TestBuildDispatchMessage_MissingScores(t *testing.T) {
-	req := baseReq()
-	delete(req.Data, "homeTeamGoals")
-	delete(req.Data, "awayTeamGoals")
-	cs := unmarshalCS(t, mustBuild(t, req))
-	if cs.HomeScore != 0 || cs.AwayScore != 0 {
-		t.Errorf("missing scores should default to 0, got home=%d away=%d", cs.HomeScore, cs.AwayScore)
-	}
+	withChannels(t, map[string]string{"BOS": "chan-BOS", "NYR": "chan-NYR"}, false, func() {
+		req := baseReq()
+		delete(req.Data, "homeTeamGoals")
+		delete(req.Data, "awayTeamGoals")
+		cs := unmarshalCS(t, mustBuild(t, req, false))
+		if cs.HomeScore != 0 || cs.AwayScore != 0 {
+			t.Errorf("missing scores should default to 0, got home=%d away=%d", cs.HomeScore, cs.AwayScore)
+		}
+	})
 }
 
 func TestChannelsForTeams_BothRegistered(t *testing.T) {
@@ -367,4 +343,28 @@ func TestChannelsForTeams_SameTeam(t *testing.T) {
 			t.Errorf("same-team edge case: want 1 channel, got %d", len(ch))
 		}
 	})
+}
+
+// Helpers
+
+func mustBuild(t *testing.T, req NotificationRequest, useDevChannels bool) string {
+	t.Helper()
+	msg, err := BuildDispatchMessage(req, useDevChannels)
+	if err != nil {
+		t.Fatalf("BuildDispatchMessage: %v", err)
+	}
+	return msg
+}
+
+func unmarshalCS(t *testing.T, msg string) contentState {
+	t.Helper()
+	var env dispatchEnvelope
+	if err := json.Unmarshal([]byte(msg), &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	var payload apnsPayload
+	if err := json.Unmarshal(env.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	return payload.APS.ContentState
 }


### PR DESCRIPTION
## Summary

- Drops the generic `lastEvent` string field from the Live Activity `content-state` payload
- Adds three structured fields: `eventType` ("goal"|"penalty"|"period_end"|""), `eventDetail` (scorer name — empty until the play-by-play scorer pipeline lands), and `eventTeam` (tricode of the team that caused the event)
- New `classifyEvent()` function maps NHL play type keys to the structured fields
- All existing tests updated; 8 new test cases added covering the new fields, fallbacks, and `classifyEvent` directly

## Why

The iOS widget (branch `NelsonBlakeN/live-activity-redesign`) needs structured event data to:
- Align scorer/penalty text to the correct team's side of the score row
- Distinguish goals vs penalties for display
- Surface scorer names when the play-by-play pipeline is wired up (separate TODO)

## Wire format change

**Before:**
```json
"content-state": { ..., "lastEvent": "Goal scored" }
```

**After:**
```json
"content-state": { ..., "eventType": "goal", "eventDetail": "", "eventTeam": "BOS" }
```

## Deployment note

The iOS app retains backward-compat decoding of `lastEvent` and will degrade gracefully if this backend change rolls back. Recommended order: deploy this backend change first, then ship the iOS update.

`eventDetail` (scorer name) is intentionally empty pending a separate task to capture it from the NHL play-by-play feed.

## Test plan
- [ ] `go test ./internal/notification/liveactivity/...` passes (verified locally)
- [ ] Deploy to staging and confirm a goal push lands with `eventType: "goal"` in the payload
- [ ] Confirm iOS widget renders "Goal" on the correct team side

🤖 Generated with [Claude Code](https://claude.com/claude-code)