### PR TITLE
fix(k8s): split NOTIFIERS config per pod for handler and scheduler

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -17,4 +17,3 @@ data:
   SCHEDULER_SHOULD_NOTIFY: "true"
   USE_TASKS_EMULATOR: "true"
   TEAM_FILTER: "DAL,CAR,VGK"
-  NOTIFIERS: "liveactivity"

--- a/k8s/cronjob-scheduler.yaml
+++ b/k8s/cronjob-scheduler.yaml
@@ -19,6 +19,8 @@ spec:
               env:
                 - name: SCHEDULER_QUEUE
                   value: cloudtasks
+                - name: NOTIFIERS
+                  value: "discord"
               envFrom:
                 - configMapRef:
                     name: app-config

--- a/k8s/deployment-handler.yaml
+++ b/k8s/deployment-handler.yaml
@@ -20,6 +20,9 @@ spec:
           ports:
             - containerPort: 8080
           args: ["-mode=http"]
+          env:
+            - name: NOTIFIERS
+              value: "liveactivity"
           envFrom:
             - configMapRef:
                 name: app-config


### PR DESCRIPTION
Previously both the handler and scheduler pods inherited `NOTIFIERS=liveactivity` from the shared `app-config` ConfigMap, which left the scheduler with no usable notifier ("No notifiers configured, skipping notification"). This moves `NOTIFIERS` out of the ConfigMap and sets it per-pod via the `env` block (which overrides `envFrom`), so the handler registers only `liveactivity` and the scheduler registers only `discord`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)