### PR TITLE
fix(scheduler): use notifiers factory to register configured notifiers

### DIFF
--- a/watchgameupdates/cmd/schedulegametrackers/main.go
+++ b/watchgameupdates/cmd/schedulegametrackers/main.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"watchgameupdates/config"
-	"watchgameupdates/internal/notification"
+	"watchgameupdates/internal/notification/notifiers"
 	"watchgameupdates/internal/queue"
 	"watchgameupdates/internal/schedule"
 	"watchgameupdates/internal/scheduler"
@@ -43,7 +43,7 @@ func main() {
 	date := schedule.ResolveTargetDate(cfg.ScheduleDate)
 
 	// Create notification service for scheduler completion summary
-	notifService := notification.NewServiceWithNotificationFlag(cfg.SchedulerNotify)
+	notifService := notifiers.New(cfg.SchedulerNotify)
 	defer notifService.Close()
 
 	// Create and run scheduler


### PR DESCRIPTION
The scheduler was calling `notification.NewServiceWithNotificationFlag` directly, which creates an empty service and never reads the `NOTIFIERS` env var — causing "No notifiers configured, skipping notification" even when `NOTIFIERS=discord` was set in the pod. Switching to `notifiers.New()` routes through the factory that reads and wires up the configured notifiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)