### PR TITLE
fix(notification): reuse APNs notifier across requests to stop 429s

### DIFF
--- a/watchgameupdates/cmd/watchgameupdates/main.go
+++ b/watchgameupdates/cmd/watchgameupdates/main.go
@@ -10,6 +10,7 @@ import (
 	"watchgameupdates/config"
 	"watchgameupdates/internal/handlers"
 	"watchgameupdates/internal/models"
+	"watchgameupdates/internal/notification"
 	"watchgameupdates/internal/notification/notifiers"
 	"watchgameupdates/internal/services"
 	"watchgameupdates/internal/tasks"
@@ -18,34 +19,37 @@ import (
 	"github.com/hibiken/asynq"
 )
 
-func httpHandler(w http.ResponseWriter, r *http.Request) {
+func makeHTTPHandler(svc *notification.Service) http.HandlerFunc {
 	fetcher := &services.HTTPGameDataFetcher{}
+	return func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "Failed to read request body", http.StatusBadRequest)
+			return
+		}
 
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		http.Error(w, "Failed to read request body", http.StatusBadRequest)
-		return
+		var payload models.Payload
+		if err := json.Unmarshal(body, &payload); err != nil {
+			http.Error(w, "Invalid request payload", http.StatusBadRequest)
+			return
+		}
+
+		shouldNotify := payload.ShouldNotify == nil || *payload.ShouldNotify
+		handlers.WatchGameUpdatesHandler(
+			w,
+			r,
+			fetcher,
+			svc.WithShouldNotify(shouldNotify),
+			payload)
 	}
-
-	var payload models.Payload
-	if err := json.Unmarshal(body, &payload); err != nil {
-		http.Error(w, "Invalid request payload", http.StatusBadRequest)
-		return
-	}
-
-	shouldNotify := payload.ShouldNotify == nil || *payload.ShouldNotify
-	notificationService := notifiers.New(shouldNotify)
-
-	handlers.WatchGameUpdatesHandler(
-		w,
-		r,
-		fetcher,
-		notificationService,
-		payload)
 }
 
 func startHTTPMode(cfg *config.Config) {
 	log.Println("Starting in HTTP mode (Cloud Tasks)")
+
+	// Build the notification service once so JWT signers and HTTP connections are
+	// reused across requests. Per-request shouldNotify is applied via WithShouldNotify.
+	sharedNotifService := notifiers.New(true)
 
 	log.Printf("Config loaded:")
 	log.Printf("  APP_ENV:                    %s", cfg.Env)
@@ -58,7 +62,7 @@ func startHTTPMode(cfg *config.Config) {
 	log.Printf("  MESSAGE_INTERVAL_SECONDS:   %d", cfg.MessageIntervalSeconds)
 	log.Printf("  PERIOD_END_INTERVAL_SECONDS:%d", cfg.PeriodEndIntervalSeconds)
 
-	funcframework.RegisterHTTPFunction("/", httpHandler)
+	funcframework.RegisterHTTPFunction("/", makeHTTPHandler(sharedNotifService))
 	if err := funcframework.Start("8080"); err != nil {
 		log.Fatalf("Failed to start function: %v", err)
 	}

--- a/watchgameupdates/internal/notification/service.go
+++ b/watchgameupdates/internal/notification/service.go
@@ -175,3 +175,15 @@ func (s *Service) RegisterNotifier(n Notifier) {
 	s.allRequiredDataKeys = append(s.allRequiredDataKeys, n.GetRequiredDataKeys()...)
 	s.notifiers = append(s.notifiers, n)
 }
+
+// WithShouldNotify returns a per-request view of this service with the given
+// notification flag. Notifier instances (and their JWT/connection state) are
+// shared with the original — call this on a long-lived service to avoid
+// recreating notifiers on every request.
+func (s *Service) WithShouldNotify(shouldNotify bool) *Service {
+	return &Service{
+		notifiers:           s.notifiers,
+		allRequiredDataKeys: s.allRequiredDataKeys,
+		shouldNotify:        shouldNotify,
+	}
+}

--- a/watchgameupdates/internal/tasks/handler.go
+++ b/watchgameupdates/internal/tasks/handler.go
@@ -8,6 +8,7 @@ import (
 
 	"watchgameupdates/config"
 	"watchgameupdates/internal/models"
+	"watchgameupdates/internal/notification"
 	"watchgameupdates/internal/notification/notifiers"
 	"watchgameupdates/internal/services"
 
@@ -21,12 +22,15 @@ type TaskEnqueuer interface {
 
 // WatchGameUpdatesHandler processes game update tasks from the Redis queue.
 type WatchGameUpdatesHandler struct {
-	cfg      *config.Config
-	enqueuer TaskEnqueuer
+	cfg                 *config.Config
+	enqueuer            TaskEnqueuer
+	notificationService *notification.Service
 }
 
 func NewWatchGameUpdatesHandler(cfg *config.Config, enqueuer TaskEnqueuer) *WatchGameUpdatesHandler {
-	return &WatchGameUpdatesHandler{cfg: cfg, enqueuer: enqueuer}
+	// Build once so JWT signers and HTTP connections survive across task invocations.
+	svc := notifiers.New(true)
+	return &WatchGameUpdatesHandler{cfg: cfg, enqueuer: enqueuer, notificationService: svc}
 }
 
 func (h *WatchGameUpdatesHandler) ProcessTask(ctx context.Context, t *asynq.Task) error {
@@ -51,15 +55,11 @@ func (h *WatchGameUpdatesHandler) ProcessTask(ctx context.Context, t *asynq.Task
 		return nil
 	}
 
-	// Build processor with fresh notification service
 	fetcher := &services.HTTPGameDataFetcher{}
 	shouldNotify := payload.ShouldNotify == nil || *payload.ShouldNotify
-	notificationService := notifiers.New(shouldNotify)
-	defer notificationService.Close()
-
 	processor := &services.GameProcessor{
 		Fetcher:             fetcher,
-		NotificationService: notificationService,
+		NotificationService: h.notificationService.WithShouldNotify(shouldNotify),
 	}
 
 	result := processor.ProcessGameUpdate(payload)


### PR DESCRIPTION
## Summary

- The APNs client was being recreated on every request, minting a new JWT auth token each poll cycle (~once per minute during live games). Apple's `TooManyProviderTokenUpdates` rate limit triggers when a provider key generates tokens more than ~once per 20 minutes, causing all subsequent pushes with that key to 429.
- Added `Service.WithShouldNotify(bool)` to `notification.Service`, which returns a per-request view sharing the underlying notifier instances (and their `jwtSigner` caches) without rebuilding them.
- Both the HTTP handler (`cmd/watchgameupdates/main.go`) and the asynq worker (`internal/tasks/handler.go`) now build the notification service once at startup and call `WithShouldNotify` per request/task instead of calling `notifiers.New`.

## Test plan

- [ ] Verify `LiveActivity notifier initialized` logs only once at handler startup (not per-request)
- [ ] Confirm APNs push responses return `200` consistently once deployed, with no `TooManyProviderTokenUpdates` 429s
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)