### PR TITLE
fix(handlers): use typed function registration to prevent startup panic

### DIFF
--- a/watchgameupdates/cmd/watchgameupdates/main.go
+++ b/watchgameupdates/cmd/watchgameupdates/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"io"
@@ -62,7 +63,13 @@ func startHTTPMode(cfg *config.Config) {
 	log.Printf("  MESSAGE_INTERVAL_SECONDS:   %d", cfg.MessageIntervalSeconds)
 	log.Printf("  PERIOD_END_INTERVAL_SECONDS:%d", cfg.PeriodEndIntervalSeconds)
 
-	funcframework.RegisterHTTPFunction("/", makeHTTPHandler(sharedNotifService))
+	// Use the typed registration entrypoint so the handler signature is checked
+	// at compile time. RegisterHTTPFunction takes interface{} and panics at
+	// startup if the dynamic type is not exactly func(http.ResponseWriter,
+	// *http.Request) — http.HandlerFunc is a named type and fails that assertion.
+	if err := funcframework.RegisterHTTPFunctionContext(context.Background(), "/", makeHTTPHandler(sharedNotifService)); err != nil {
+		log.Fatalf("Failed to register function: %v", err)
+	}
 	if err := funcframework.Start("8080"); err != nil {
 		log.Fatalf("Failed to start function: %v", err)
 	}


### PR DESCRIPTION
## Summary

- `RegisterHTTPFunction` takes `interface{}` and uses a strict type assertion against `func(http.ResponseWriter, *http.Request)`; `http.HandlerFunc` is a named type and fails that assertion at runtime, causing the handler pod to panic on every startup
- Replaced with `RegisterHTTPFunctionContext`, which accepts the typed signature directly — a signature mismatch now fails at compile time instead of crashing the pod
- The shared `notification.Service` (introduced in #52 to prevent APNs 429s) is preserved; this fix unblocks the pod so it can actually receive Cloud Tasks

## Test plan
- [ ] Handler pod starts cleanly with 0 restarts (verified in cluster on this branch: `handler:nelsonblaken-fix-http-handler-panic-394767e`)
- [ ] No panic message in pod logs
- [ ] APNs notifier initializes once at boot (`LiveActivity notifier initialized` log line present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)