### PR TITLE
fix(liveactivity): retry on MoneyPuck CSV parse error instead of pushing empty state

### DIFF
--- a/watchgameupdates/internal/handlers/watchgameupdates_handler.go
+++ b/watchgameupdates/internal/handlers/watchgameupdates_handler.go
@@ -53,6 +53,11 @@ func WatchGameUpdatesHandler(
 	if result.ShouldReschedule {
 		cfg := config.LoadConfig()
 		interval := services.RescheduleInterval(result.LastPlay, result.MaxPeriods, cfg)
+		if result.RetryAfterDataError {
+			// MoneyPuck data was unparseable and nothing was sent; ignore the
+			// play-type interval and retry soon to pick up the corrected file.
+			interval = services.ParseErrorRetryInterval
+		}
 		if err := scheduleNextCheck(payload, interval); err != nil {
 			log.Printf("Failed to schedule next check: %v", err)
 			http.Error(w, "Failed to schedule next check", http.StatusInternalServerError)

--- a/watchgameupdates/internal/services/fetcher.go
+++ b/watchgameupdates/internal/services/fetcher.go
@@ -2,11 +2,18 @@ package services
 
 import (
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
 )
+
+// ErrCSVParse classifies a failure to parse the MoneyPuck CSV (e.g. a transient
+// malformed row such as a bare quote in an unquoted field). It is distinct from
+// HTTP/network failures so callers can choose to retry shortly instead of
+// notifying with missing data. Test for it with errors.Is(err, ErrCSVParse).
+var ErrCSVParse = errors.New("moneypuck CSV parse error")
 
 type GameDataFetcher interface {
 	FetchGameData(gameID string) ([][]string, error)
@@ -125,6 +132,12 @@ func (f *HTTPGameDataFetcher) FetchGameData(gameID string) ([][]string, error) {
 	records, err := reader.ReadAll()
 	if err != nil {
 		log.Printf("ERROR: Failed to parse CSV data for game %s: %v", gameID, err)
+		// A *csv.ParseError means MoneyPuck served a malformed file; tag it as
+		// ErrCSVParse so callers can retry. Other (I/O) errors pass through as-is.
+		var parseErr *csv.ParseError
+		if errors.As(err, &parseErr) {
+			return nil, fmt.Errorf("%w: %w", ErrCSVParse, err)
+		}
 		return nil, err
 	}
 

--- a/watchgameupdates/internal/services/fetcher_test.go
+++ b/watchgameupdates/internal/services/fetcher_test.go
@@ -1,0 +1,71 @@
+package services
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// serveCSV starts a test server returning the given body and points the
+// MoneyPuck fetcher at it via STATS_API_BASE_URL. The returned cleanup is
+// registered with t.Cleanup.
+func serveCSV(t *testing.T, body string) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/csv")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Setenv("STATS_API_BASE_URL", srv.URL)
+	t.Cleanup(srv.Close)
+}
+
+func TestFetchAndParseGameData_MalformedCSVIsClassifiedAsParseError(t *testing.T) {
+	// A bare " in an unquoted field — the exact failure MoneyPuck served during
+	// the live game. encoding/csv rejects it with *csv.ParseError.
+	serveCSV(t, "id,homeTeamGoals,eventDescriptionRaw\n"+
+		"1,2,Tkachuk 6'2\" wrister\n")
+
+	f := &HTTPGameDataFetcher{}
+	_, err := f.FetchAndParseGameData("2025030415", []string{"homeTeamGoals"})
+
+	if err == nil {
+		t.Fatal("expected an error for malformed CSV, got nil")
+	}
+	if !errors.Is(err, ErrCSVParse) {
+		t.Errorf("expected error to match ErrCSVParse, got %v", err)
+	}
+}
+
+func TestFetchAndParseGameData_ValidCSVIsNotParseError(t *testing.T) {
+	serveCSV(t, "id,homeTeamGoals,awayTeamGoals\n"+
+		"1,2,1\n")
+
+	f := &HTTPGameDataFetcher{}
+	data, err := f.FetchAndParseGameData("2025030415", []string{"homeTeamGoals", "awayTeamGoals"})
+
+	if err != nil {
+		t.Fatalf("unexpected error for valid CSV: %v", err)
+	}
+	if data["homeTeamGoals"] != "2" || data["awayTeamGoals"] != "1" {
+		t.Errorf("unexpected extracted values: %v", data)
+	}
+}
+
+func TestFetchAndParseGameData_HTTPErrorIsNotClassifiedAsParseError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	t.Setenv("STATS_API_BASE_URL", srv.URL)
+	defer srv.Close()
+
+	f := &HTTPGameDataFetcher{}
+	_, err := f.FetchAndParseGameData("2025030415", []string{"homeTeamGoals"})
+
+	if err == nil {
+		t.Fatal("expected an error for non-200 response, got nil")
+	}
+	if errors.Is(err, ErrCSVParse) {
+		t.Errorf("HTTP error should not be classified as ErrCSVParse, got %v", err)
+	}
+}

--- a/watchgameupdates/internal/services/gameprocessor.go
+++ b/watchgameupdates/internal/services/gameprocessor.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -10,6 +11,11 @@ import (
 	"watchgameupdates/internal/models"
 	"watchgameupdates/internal/notification"
 )
+
+// ParseErrorRetryInterval is how long to wait before retrying a game check after
+// the MoneyPuck CSV failed to parse. The malformed file is usually transient, so
+// we retry the same scenario shortly rather than notifying with missing data.
+const ParseErrorRetryInterval = 1 * time.Minute
 
 // GameProcessor contains the shared game-check logic used by both the HTTP handler
 // and the asynq worker handler. It is stateless and safe for concurrent use.
@@ -23,6 +29,10 @@ type ProcessResult struct {
 	ShouldReschedule bool
 	LastPlay         models.Play
 	MaxPeriods       *int
+	// RetryAfterDataError is set when the MoneyPuck CSV could not be parsed. No
+	// notification was sent this cycle; the caller should reschedule a short retry
+	// (ParseErrorRetryInterval) rather than the normal play-type interval.
+	RetryAfterDataError bool
 }
 
 // ShouldSkipExecution returns true if the current time is past the execution end window.
@@ -61,6 +71,22 @@ func (gp *GameProcessor) ProcessGameUpdate(payload models.Payload) ProcessResult
 
 		requiredKeys := gp.NotificationService.GetAllRequiredDataKeys()
 		gameData, err := gp.Fetcher.FetchAndParseGameData(payload.Game.ID, requiredKeys)
+
+		// A CSV parse error means MoneyPuck served a malformed (usually transient)
+		// file. Notifying now would push a zeroed content-state (0-0, empty
+		// gameState → "Pregame" on iOS). Instead, send nothing and retry shortly so
+		// the next fetch can pick up the corrected file.
+		if errors.Is(err, ErrCSVParse) {
+			log.Printf("WARNING: MoneyPuck CSV parse error for game %s; skipping notification and retrying in %s: %v",
+				payload.Game.ID, ParseErrorRetryInterval, err)
+			return ProcessResult{
+				ShouldReschedule:    true,
+				LastPlay:            lastPlay,
+				MaxPeriods:          maxPeriods,
+				RetryAfterDataError: true,
+			}
+		}
+
 		if err != nil {
 			log.Printf("ERROR: Failed to fetch and parse MoneyPuck data for game %s: %v", payload.Game.ID, err)
 		}

--- a/watchgameupdates/internal/services/gameprocessor_parseerror_test.go
+++ b/watchgameupdates/internal/services/gameprocessor_parseerror_test.go
@@ -1,0 +1,106 @@
+package services
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"watchgameupdates/internal/models"
+	"watchgameupdates/internal/notification"
+)
+
+// recordingNotifier satisfies notification.Notifier and flips `sent` the moment
+// it is asked to format or send anything, so a test can assert that the parse-
+// error path never reaches the notifiers.
+type recordingNotifier struct {
+	sent atomic.Bool
+}
+
+func (n *recordingNotifier) GetRequiredDataKeys() []string { return []string{"homeTeamGoals"} }
+
+func (n *recordingNotifier) FormatMessage(req notification.NotificationRequest) string {
+	n.sent.Store(true)
+	return ""
+}
+
+func (n *recordingNotifier) SendNotification(ctx context.Context, message string) (<-chan notification.NotificationResult, error) {
+	n.sent.Store(true)
+	ch := make(chan notification.NotificationResult, 1)
+	ch <- notification.NotificationResult{Success: true, ID: "test"}
+	close(ch)
+	return ch, nil
+}
+
+func (n *recordingNotifier) Close() error { return nil }
+
+// TestProcessGameUpdate_CSVParseErrorSkipsNotifyAndRetries drives the full
+// ProcessGameUpdate path against a play-by-play server that reports a period-end
+// and a MoneyPuck server that returns a malformed CSV. The processor must send
+// nothing and signal a short retry.
+func TestProcessGameUpdate_CSVParseErrorSkipsNotifyAndRetries(t *testing.T) {
+	// Play-by-play: last play is a period-end (a recompute type → triggers fetch).
+	pbp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"plays":[{"typeDescKey":"period-end","periodDescriptor":{"number":1,"periodType":"REG"},"timeRemaining":"00:00"}]}`))
+	}))
+	defer pbp.Close()
+	t.Setenv("PLAYBYPLAY_API_BASE_URL", pbp.URL)
+
+	// MoneyPuck: malformed CSV (bare quote in an unquoted field).
+	serveCSV(t, "id,homeTeamGoals\n1,Tkachuk 6'2\" wrister\n")
+
+	notifier := &recordingNotifier{}
+	svc := notification.NewServiceWithNotificationFlag(true)
+	svc.RegisterNotifier(notifier)
+
+	gp := &GameProcessor{Fetcher: &HTTPGameDataFetcher{}, NotificationService: svc}
+
+	result := gp.ProcessGameUpdate(models.Payload{
+		Game: models.Game{
+			ID:       "2025030415",
+			HomeTeam: models.Team{Abbrev: "CAR", CommonName: map[string]string{"default": "Hurricanes"}},
+			AwayTeam: models.Team{Abbrev: "FLA", CommonName: map[string]string{"default": "Panthers"}},
+		},
+	})
+
+	if notifier.sent.Load() {
+		t.Error("expected no notification to be sent on a CSV parse error")
+	}
+	if !result.RetryAfterDataError {
+		t.Error("expected RetryAfterDataError=true on a CSV parse error")
+	}
+	if !result.ShouldReschedule {
+		t.Error("expected ShouldReschedule=true so the check is retried")
+	}
+}
+
+// TestProcessGameUpdate_ValidCSVNotifies is the control: a well-formed CSV must
+// still reach the notifier and must not request the parse-error retry.
+func TestProcessGameUpdate_ValidCSVNotifies(t *testing.T) {
+	pbp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"plays":[{"typeDescKey":"goal","periodDescriptor":{"number":1,"periodType":"REG"},"timeRemaining":"12:00"}]}`))
+	}))
+	defer pbp.Close()
+	t.Setenv("PLAYBYPLAY_API_BASE_URL", pbp.URL)
+
+	serveCSV(t, "id,homeTeamGoals\n1,2\n")
+
+	notifier := &recordingNotifier{}
+	svc := notification.NewServiceWithNotificationFlag(true)
+	svc.RegisterNotifier(notifier)
+
+	gp := &GameProcessor{Fetcher: &HTTPGameDataFetcher{}, NotificationService: svc}
+
+	result := gp.ProcessGameUpdate(models.Payload{
+		Game: models.Game{
+			ID:       "2025030415",
+			HomeTeam: models.Team{Abbrev: "CAR", CommonName: map[string]string{"default": "Hurricanes"}},
+			AwayTeam: models.Team{Abbrev: "FLA", CommonName: map[string]string{"default": "Panthers"}},
+		},
+	})
+
+	if result.RetryAfterDataError {
+		t.Error("expected RetryAfterDataError=false for a valid CSV")
+	}
+}

--- a/watchgameupdates/internal/tasks/handler.go
+++ b/watchgameupdates/internal/tasks/handler.go
@@ -65,7 +65,13 @@ func (h *WatchGameUpdatesHandler) ProcessTask(ctx context.Context, t *asynq.Task
 	result := processor.ProcessGameUpdate(payload)
 
 	if result.ShouldReschedule {
-		if err := h.scheduleNextCheck(payload); err != nil {
+		interval := time.Duration(h.cfg.MessageIntervalSeconds) * time.Second
+		if result.RetryAfterDataError {
+			// MoneyPuck data was unparseable and nothing was sent; retry soon to
+			// pick up the corrected file.
+			interval = services.ParseErrorRetryInterval
+		}
+		if err := h.scheduleNextCheck(payload, interval); err != nil {
 			return fmt.Errorf("failed to schedule next check for game %s: %w", payload.Game.ID, err)
 		}
 	}
@@ -73,13 +79,12 @@ func (h *WatchGameUpdatesHandler) ProcessTask(ctx context.Context, t *asynq.Task
 	return nil
 }
 
-func (h *WatchGameUpdatesHandler) scheduleNextCheck(payload models.Payload) error {
+func (h *WatchGameUpdatesHandler) scheduleNextCheck(payload models.Payload, interval time.Duration) error {
 	task, err := NewWatchGameUpdatesTask(payload)
 	if err != nil {
 		return fmt.Errorf("failed to create task: %w", err)
 	}
 
-	interval := time.Duration(h.cfg.MessageIntervalSeconds) * time.Second
 	info, err := h.enqueuer.Enqueue(task, asynq.ProcessIn(interval))
 	if err != nil {
 		return fmt.Errorf("failed to enqueue task: %w", err)

--- a/watchgameupdates/internal/tasks/handler_test.go
+++ b/watchgameupdates/internal/tasks/handler_test.go
@@ -135,7 +135,7 @@ func TestScheduleNextCheck_EnqueuesCalled(t *testing.T) {
 		Game: models.Game{ID: "2024030411"},
 	}
 
-	err := h.scheduleNextCheck(payload)
+	err := h.scheduleNextCheck(payload, time.Duration(cfg.MessageIntervalSeconds)*time.Second)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -170,7 +170,7 @@ func TestScheduleNextCheck_EnqueueError(t *testing.T) {
 		Game: models.Game{ID: "2024030411"},
 	}
 
-	err := h.scheduleNextCheck(payload)
+	err := h.scheduleNextCheck(payload, time.Duration(cfg.MessageIntervalSeconds)*time.Second)
 	if err == nil {
 		t.Error("Expected error when enqueue fails, got nil")
 	}


### PR DESCRIPTION
## Problem

During a live game's first intermission, the Live Activity showed **"Pregame"** (with 0–0 and 0.00 xG). Traced via staging handler logs to a malformed MoneyPuck CSV:

```
ERROR: Failed to parse CSV data for game 2025030415: parse error on line 111,
       column 39: bare " in non-quoted-field
WARNING: Required data key 'gameState'/'homeTeamGoals'/... not found in game data
APNs push: status=200   ← pushed anyway, with an empty content-state
```

A bare `"` in an unquoted field made `encoding/csv` abort the **entire** parse, returning `nil`. `ProcessGameUpdate` then skipped populating `gameState` (the `if gameData != nil` guard), and the notifier sent a fully-defaulted content-state. On iOS, an empty `gameState` renders as "Pregame".

## Fix

Treat a CSV parse error as "data not ready yet": **send nothing, retry shortly.**

- `fetcher.go` — classify `*csv.ParseError` as a new `ErrCSVParse` sentinel, distinct from HTTP/network errors (which keep existing behavior).
- `gameprocessor.go` — on `errors.Is(err, ErrCSVParse)`, `ProcessGameUpdate` returns before notifying, with `ShouldReschedule: true` and a new `RetryAfterDataError` flag. Adds `const ParseErrorRetryInterval = 1 * time.Minute`.
- `watchgameupdates_handler.go` (Cloud Tasks) and `tasks/handler.go` (asynq) — on `RetryAfterDataError`, override the play-type interval with the 1-minute retry so the next fetch picks up MoneyPuck's corrected file.

Only genuine parse errors are affected; HTTP/non-200/network failures are unchanged.

## Tests

- `fetcher_test.go` — malformed CSV → `ErrCSVParse`; valid CSV → no error + correct extraction; HTTP 500 → error but **not** `ErrCSVParse`.
- `gameprocessor_parseerror_test.go` — full `ProcessGameUpdate` against httptest play-by-play (period-end) + malformed MoneyPuck CSV: asserts **no notifier is invoked** and `RetryAfterDataError`/`ShouldReschedule` are set; plus a valid-CSV control.

`go build ./...`, `go vet ./...`, and `go test ./...` (incl. `-race`) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)