### PR TITLE
feat(k8s): offseason staging deploys route to game data emulator

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,6 +77,7 @@ jobs:
 
       - name: Resolve environment
         id: env
+        shell: bash
         run: |
           if [ "${{ github.event_name }}" = "workflow_run" ]; then
             ENVIRONMENT=staging

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,10 +89,21 @@ jobs:
             *) echo "ERROR: unknown environment '$ENVIRONMENT'"; exit 1 ;;
           esac
           OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          # Offseason routing: Jun 22 – Sep 30 (any year) in UTC.
+          # Force base-10 parsing to avoid octal interpretation of 06xx dates.
+          OVERLAY="$ENVIRONMENT"
+          if [ "$ENVIRONMENT" = "staging" ]; then
+            MMDD=$(date -u +%m%d)
+            if [ $((10#$MMDD)) -ge 622 ] && [ $((10#$MMDD)) -le 930 ]; then
+              OVERLAY="staging-offseason"
+              echo "Offseason window active (${MMDD} UTC) -> routing staging to game data emulator"
+            fi
+          fi
           echo "environment=$ENVIRONMENT" >> "$GITHUB_OUTPUT"
           echo "namespace=$NAMESPACE"     >> "$GITHUB_OUTPUT"
           echo "owner=$OWNER"             >> "$GITHUB_OUTPUT"
-          echo "Deploying to $ENVIRONMENT (namespace $NAMESPACE)"
+          echo "overlay=$OVERLAY"         >> "$GITHUB_OUTPUT"
+          echo "Deploying to $ENVIRONMENT (namespace $NAMESPACE, overlay $OVERLAY)"
 
       - name: Compute image tag
         id: image-tag
@@ -153,7 +164,7 @@ jobs:
         env:
           IMAGE_TAG: ${{ steps.image-tag.outputs.tag }}
         run: |
-          kubectl kustomize "k8s/overlays/${{ steps.env.outputs.environment }}/app" \
+          kubectl kustomize "k8s/overlays/${{ steps.env.outputs.overlay }}/app" \
             | envsubst '${IMAGE_TAG}' > rendered-app.yaml
           echo "----- rendered workloads -----"
           cat rendered-app.yaml

--- a/.github/workflows/validate-manifests.yml
+++ b/.github/workflows/validate-manifests.yml
@@ -33,4 +33,7 @@ jobs:
                 | envsubst '${IMAGE_TAG}' > "rendered/${env}-${layer}.yaml"
             done
           done
+          # staging-offseason has no infra overlay (shares firepower-staging namespace/services)
+          kubectl kustomize "k8s/overlays/staging-offseason/app" \
+            | envsubst '${IMAGE_TAG}' > "rendered/staging-offseason-app.yaml"
           kubeconform -strict -summary -output pretty rendered/

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ backend/
 │   │   └── infra/               # Services (owned by infrastructure pipeline)
 │   └── overlays/
 │       ├── production/          # firepower namespace, prod config
-│       └── staging/             # firepower-staging namespace, silent notifiers
+│       ├── staging/             # firepower-staging namespace
+│       └── staging-offseason/   # staging + emulator data routing (Jun 22–Sep 30)
 ├── docs/                        # Documentation
 │   └── queue-visualization.md   # Asynqmon dashboard guide
 ├── docker-compose.yml           # Cloud Tasks orchestration
@@ -595,7 +596,9 @@ The cluster uses two namespaces: `firepower` (production) and `firepower-staging
 # where <sha> is the 7-char commit SHA you verified in staging
 ```
 
-The staging overlay silences all notifiers (`NOTIFIERS=""` on both handler and scheduler) so staging runs never post to real Discord channels or fire APNs pushes.
+Staging sends real notifications (LiveActivity APNs push and Discord) using the same notifier config as production.
+
+**Offseason routing (Jun 22–Sep 30):** When a staging deploy lands inside this window, the pipeline automatically renders the `staging-offseason` overlay instead of `staging`. This points all three data-source env vars (`PLAYBYPLAY_API_BASE_URL`, `STATS_API_BASE_URL`, `SCHEDULE_API_BASE_URL`) at the in-cluster `gamedataemulator` Service and sets `TEAM_FILTER=DAL,CAR,VGK,CHI` so the emulator's schedule is exercised immediately. The handler and scheduler run unchanged — they just read URLs and stay oblivious to the swap. The routing reverts automatically on the first deploy after Sep 30.
 
 ### Cloud Tasks (HTTP Mode — local/manual)
 

--- a/k8s/overlays/staging-offseason/app/kustomization.yaml
+++ b/k8s/overlays/staging-offseason/app/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: firepower-staging
-
 resources:
   - ../../staging/app
 

--- a/k8s/overlays/staging-offseason/app/kustomization.yaml
+++ b/k8s/overlays/staging-offseason/app/kustomization.yaml
@@ -1,0 +1,28 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: firepower-staging
+
+resources:
+  - ../../staging/app
+
+patches:
+  - target:
+      kind: ConfigMap
+      name: app-config
+    patch: |-
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: app-config
+      data:
+        # Offseason (Jun 22 – Sep 30): pull simulated data from the in-cluster
+        # game data emulator so the full pipeline keeps running with no live games.
+        PLAYBYPLAY_API_BASE_URL: "http://gamedataemulator:8125"
+        STATS_API_BASE_URL: "http://gamedataemulator:8124"
+        SCHEDULE_API_BASE_URL: "http://gamedataemulator:8125"
+        # CHI added because the emulator's first-week slate (FLA/CHI/NYR/PIT/LAK/COL)
+        # does not overlap with DAL/CAR/VGK; adding CHI ensures ≥1 game/day is
+        # scheduled immediately. DAL/CAR/VGK naturally appear in the richer Jul-1+
+        # slate and are kept so they continue to be exercised later in the offseason.
+        TEAM_FILTER: "DAL,CAR,VGK,CHI"


### PR DESCRIPTION
## Summary

- Adds `k8s/overlays/staging-offseason/app` — a kustomize overlay that bases on `staging` and patches `app-config` to point all three data-source URLs (`PLAYBYPLAY_API_BASE_URL`, `STATS_API_BASE_URL`, `SCHEDULE_API_BASE_URL`) at the in-cluster `gamedataemulator` Service and sets `TEAM_FILTER=DAL,CAR,VGK,CHI` so the emulator's first-week slate schedules at least one game per day.
- Updates `deploy.yml` to compute an `overlay` output: when `environment=staging` and the current UTC date falls in [Jun 22, Sep 30], the pipeline renders `staging-offseason` instead of `staging`; otherwise behavior is unchanged. Self-reverts on the first post-window deploy.
- Updates `validate-manifests.yml` to kustomize-build the new overlay on every PR so it's always CI-validated.

## Test plan

- [ ] Confirm `kubectl kustomize k8s/overlays/staging-offseason/app` shows emulator URLs and `TEAM_FILTER=DAL,CAR,VGK,CHI`
- [ ] Trigger a manual `workflow_dispatch` staging deploy and verify `app-config` in `firepower-staging` shows emulator URLs
- [ ] Confirm the scheduler schedules ≥1 game/day from emulator data and notifications fire
- [ ] Verify a deploy after Sep 30 restores live URLs (or manually test by temporarily changing the date threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)