### PR TITLE
fix(notification): send exact xG values; log dispatch payload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,24 @@ make watch TEAM=COL    # E2E live test: schedule today's game and follow logs
 | Mock MoneyPuck API | 8124 |
 | Mock NHL API | 8125 |
 
+## Data Formatting Responsibility
+
+The backend sends **exact values** as sourced from upstream data (NHL API, MoneyPuck).
+The iOS client is **solely responsible for display formatting**.
+
+- Never round, truncate, or otherwise reduce the precision of numeric values
+  (e.g., xG) before putting them in a push payload. Send them exactly as parsed.
+- Never apply display formatting server-side (decimal places, locale, units,
+  abbreviations). The client decides how values are rendered (e.g., the iOS
+  widget formats xG with `%.2f`).
+- The backend's job is validation only: reject/zero malformed values (NaN, Inf,
+  unparseable strings — see `safeXG` in `notification/liveactivity/formatter.go`),
+  then pass the value through untouched.
+
+Rationale: the wire format (`content-state` in the APNs payload) is a data
+contract, not a presentation layer. Rounding server-side silently caps the
+precision every current and future client can display.
+
 ## Environment Variables
 
 Copy `.env.example` to `.env.home` or `.env.local` and populate:

--- a/watchgameupdates/internal/notification/liveactivity/formatter.go
+++ b/watchgameupdates/internal/notification/liveactivity/formatter.go
@@ -168,6 +168,8 @@ func classifyEvent(playType string, data map[string]string) (eventType, eventTea
 }
 
 // safeXG parses an xG string and guards against NaN/Inf.
+// The value passes through exactly as sourced — no rounding. Display
+// formatting is the iOS client's responsibility (see CLAUDE.md).
 func safeXG(s string) float64 {
 	if s == "" {
 		return 0
@@ -177,7 +179,7 @@ func safeXG(s string) float64 {
 		log.Printf("WARN: invalid xG value %q, defaulting to 0", s)
 		return 0
 	}
-	return math.Round(v*10) / 10
+	return v
 }
 
 func parseIntSafe(s string) int {

--- a/watchgameupdates/internal/notification/liveactivity/formatter_test.go
+++ b/watchgameupdates/internal/notification/liveactivity/formatter_test.go
@@ -293,8 +293,17 @@ func TestSafeXG_Empty(t *testing.T) {
 }
 
 func TestSafeXG_ValidFloat(t *testing.T) {
-	if got := safeXG("2.456"); got != 2.5 {
-		t.Errorf("safeXG(2.456) = %v, want 2.5", got)
+	if got := safeXG("2.456"); got != 2.456 {
+		t.Errorf("safeXG(2.456) = %v, want 2.456 (exact passthrough, no rounding)", got)
+	}
+}
+
+func TestSafeXG_NoRounding(t *testing.T) {
+	// The client owns display formatting; the backend must not round.
+	for in, want := range map[string]float64{"0.76": 0.76, "0.38": 0.38, "1.05": 1.05} {
+		if got := safeXG(in); got != want {
+			t.Errorf("safeXG(%s) = %v, want %v (exact passthrough)", in, got, want)
+		}
 	}
 }
 

--- a/watchgameupdates/internal/notification/liveactivity/notifier.go
+++ b/watchgameupdates/internal/notification/liveactivity/notifier.go
@@ -113,6 +113,7 @@ func (n *LiveActivityNotifier) SendNotification(ctx context.Context, message str
 
 // pushToAll pushes payload to all channels in parallel; returns first error encountered.
 func (n *LiveActivityNotifier) pushToAll(ctx context.Context, channels []string, payload []byte) error {
+	log.Printf("APNs dispatch: channels=%v payload=%s", channels, payload)
 	errs := make(chan error, len(channels))
 	for _, ch := range channels {
 		go func(ch string) {


### PR DESCRIPTION
## Summary
- **Remove server-side xG rounding** — `safeXG` rounded every value to one decimal (`math.Round(v*10)/10`), so 0.76 arrived on devices as 0.8 and the iOS widget's two-decimal display rendered "0.80". Values now pass through exactly as parsed from MoneyPuck data.
- **Log the exact APNs payload at dispatch time** — one line per dispatch in `pushToAll` with the verbatim payload bytes and target channels, so the wire content can be checked against what clients display.
- **Document the formatting responsibility split in CLAUDE.md** — the backend sends exact values as sourced and does validation only; the client is solely responsible for display formatting (decimals, locale, units).

## Testing
- Updated `TestSafeXG_ValidFloat` to assert exact passthrough and added `TestSafeXG_NoRounding`.
- Full suite passes: `go test ./...` from `watchgameupdates/`.

No iOS change needed — the widget already formats with `%.2f` and will show full precision as soon as this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)