### PR TITLE
feat(notification): populate all 32 prod channel IDs from iOS source of truth

### DIFF
--- a/watchgameupdates/internal/notification/liveactivity/channels.go
+++ b/watchgameupdates/internal/notification/liveactivity/channels.go
@@ -41,39 +41,46 @@ var debugChannels = map[string]string{
 // prodChannels maps NHL team tricodes to APNs broadcast channel IDs created in
 // the Production environment (App Store Connect → Push Notifications → Broadcast → Production).
 // Use these with production APNs and App Store / TestFlight builds.
+//
+// Source of truth: the iOS repo (github.com/FirepowerApp/ios) at
+// main:Firepower/NHLTeams.swift (prodChannelIds). Devices subscribe to these
+// exact IDs, so the backend replicates that map verbatim. IDs are opaque tokens
+// minted by App Store Connect and are NOT derivable from the tricode. When iOS
+// mints or rotates a channel, re-copy the value here. TestReplicateAll32ProdChannels
+// enforces that every team stays populated.
 var prodChannels = map[string]string{
-	"ANA": "",
-	"BOS": "",
-	"BUF": "",
+	"ANA": "UhYmnn8mEfEAAOYc0Q7CQQ==",
+	"BOS": "+YMYln8mEfEAADq3u4xYzw==",
+	"BUF": "Au/kwn8nEfEAAOYc0Q7CQQ==",
 	"CAR": "d4E+F1ikEfEAAF7OhT1omw==",
-	"CBJ": "",
-	"CGY": "",
+	"CBJ": "Cd+IhX8nEfEAAOK+11eG0w==",
+	"CGY": "ETvY2H8nEfEAAFr0zqCBeA==",
 	"CHI": "VeHR2HNPEfEAAIIz9BtJIg==",
 	"COL": "S7cBYlilEfEAADY6cc28lw==",
-	"DAL": "",
-	"DET": "",
-	"EDM": "",
-	"FLA": "",
-	"LAK": "",
-	"MIN": "",
+	"DAL": "GNBrYX8nEfEAALJMNogb7Q==",
+	"DET": "IwHOp38nEfEAADq3u4xYzw==",
+	"EDM": "KeUc6H8nEfEAADq3u4xYzw==",
+	"FLA": "Z9sW/X8pEfEAAOYc0Q7CQQ==",
+	"LAK": "b92xa38pEfEAAOK+11eG0w==",
+	"MIN": "eotUn38pEfEAAOYc0Q7CQQ==",
 	"MTL": "GOmex1ilEfEAAOYo81Crcg==",
-	"NJD": "",
-	"NSH": "",
-	"NYI": "",
-	"NYR": "",
-	"OTT": "",
-	"PHI": "",
-	"PIT": "",
-	"SEA": "",
-	"SJS": "",
-	"STL": "",
-	"TBL": "",
-	"TOR": "",
-	"UTA": "",
-	"VAN": "",
+	"NJD": "g1DIan8pEfEAAC4RS0Xe8Q==",
+	"NSH": "imyy238pEfEAAC4RS0Xe8Q==",
+	"NYI": "kgA+TH8pEfEAAC4RS0Xe8Q==",
+	"NYR": "miMsfn8pEfEAADq3u4xYzw==",
+	"OTT": "oLgaDH8pEfEAAOK+11eG0w==",
+	"PHI": "yMEWan8pEfEAAJYcSnrw9A==",
+	"PIT": "z8aSq38pEfEAAJYcSnrw9A==",
+	"SEA": "1tEcRn8pEfEAAD7+DDlNqw==",
+	"SJS": "3qTJ0X8pEfEAAOYc0Q7CQQ==",
+	"STL": "5Qj3Bn8pEfEAACopEMQCsQ==",
+	"TBL": "7Sjk538pEfEAAFr0zqCBeA==",
+	"TOR": "8yE1938pEfEAACopEMQCsQ==",
+	"UTA": "+NY7bn8pEfEAAC4RS0Xe8Q==",
+	"VAN": "/1iF5H8pEfEAAOYc0Q7CQQ==",
 	"VGK": "Y8GZXlikEfEAAE4quYgbSQ==",
-	"WPG": "",
-	"WSH": "",
+	"WPG": "BdfcOX8qEfEAACopEMQCsQ==",
+	"WSH": "DMyFbX8qEfEAAJYcSnrw9A==",
 }
 
 // channelForTeam looks up the APNs broadcast channel ID for a tricode.

--- a/watchgameupdates/internal/notification/liveactivity/channels_test.go
+++ b/watchgameupdates/internal/notification/liveactivity/channels_test.go
@@ -1,0 +1,47 @@
+package liveactivity
+
+import "testing"
+
+// allTricodes is the full NHL roster the backend must be able to notify. It
+// mirrors the 32-team set in the iOS source of truth
+// (github.com/FirepowerApp/ios, main:Firepower/NHLTeams.swift). Keeping it
+// explicit here means a team can never silently drop out of the prod map
+// without this test failing.
+var allTricodes = []string{
+	"ANA", "BOS", "BUF", "CAR", "CBJ", "CGY", "CHI", "COL",
+	"DAL", "DET", "EDM", "FLA", "LAK", "MIN", "MTL", "NJD",
+	"NSH", "NYI", "NYR", "OTT", "PHI", "PIT", "SEA", "SJS",
+	"STL", "TBL", "TOR", "UTA", "VAN", "VGK", "WPG", "WSH",
+}
+
+// TestReplicateAll32ProdChannels enforces the core invariant of this design:
+// every one of the 32 teams resolves to a non-empty production channel ID, so
+// channelForTeam never fails for a missing ID. This makes the scheduler's
+// TEAM_FILTER the sole guard on which teams send notifications. If iOS mints a
+// channel for a new/blank team, copy the ID into prodChannels or this fails.
+func TestReplicateAll32ProdChannels(t *testing.T) {
+	if len(prodChannels) != len(allTricodes) {
+		t.Fatalf("prodChannels has %d entries, want %d", len(prodChannels), len(allTricodes))
+	}
+	for _, tri := range allTricodes {
+		id, ok := channelForTeam(tri, false)
+		if !ok || id == "" {
+			t.Errorf("team %s has no production channel ID; every team must be populated so the scheduler filter is the only guard", tri)
+		}
+	}
+}
+
+// TestNoUnknownProdTeams guards the other direction: prodChannels must not carry
+// a tricode outside the known 32-team roster (a typo would create a channel that
+// no device ever subscribes to).
+func TestNoUnknownProdTeams(t *testing.T) {
+	known := make(map[string]bool, len(allTricodes))
+	for _, tri := range allTricodes {
+		known[tri] = true
+	}
+	for tri := range prodChannels {
+		if !known[tri] {
+			t.Errorf("prodChannels has unknown tricode %q", tri)
+		}
+	}
+}

--- a/watchgameupdates/internal/notification/liveactivity/formatter_test.go
+++ b/watchgameupdates/internal/notification/liveactivity/formatter_test.go
@@ -191,14 +191,18 @@ func TestBuildDispatchMessage_GameEnded(t *testing.T) {
 
 func TestBuildDispatchMessage_NoChannelsRegistered(t *testing.T) {
 	// Both teams have empty channel IDs — should error rather than push to nothing.
-	_, err := BuildDispatchMessage(baseReq(), false)
-	if err == nil {
-		t.Fatal("want error when no channel IDs are registered, got nil")
-	}
+	// The prod map now populates every team (see TestReplicateAll32ProdChannels),
+	// so force BOS/NYR empty to exercise the skip-empty defense.
+	withChannels(t, map[string]string{"BOS": "", "NYR": ""}, false, func() {
+		_, err := BuildDispatchMessage(baseReq(), false)
+		if err == nil {
+			t.Fatal("want error when no channel IDs are registered, got nil")
+		}
+	})
 }
 
 func TestBuildDispatchMessage_OneChannelRegistered(t *testing.T) {
-	withChannels(t, map[string]string{"BOS": "chan-BOS"}, false, func() {
+	withChannels(t, map[string]string{"BOS": "chan-BOS", "NYR": ""}, false, func() {
 		msg, err := BuildDispatchMessage(baseReq(), false)
 		if err != nil {
 			t.Fatalf("unexpected error when one channel registered: %v", err)
@@ -339,10 +343,13 @@ func TestChannelsForTeams_BothRegistered(t *testing.T) {
 }
 
 func TestChannelsForTeams_NoneRegistered(t *testing.T) {
-	ch := channelsForTeams("BOS", "NYR", false)
-	if len(ch) != 0 {
-		t.Errorf("want 0 channels when none registered, got %d", len(ch))
-	}
+	// Force BOS/NYR empty: the real prod map now populates every team.
+	withChannels(t, map[string]string{"BOS": "", "NYR": ""}, false, func() {
+		ch := channelsForTeams("BOS", "NYR", false)
+		if len(ch) != 0 {
+			t.Errorf("want 0 channels when none registered, got %d", len(ch))
+		}
+	})
 }
 
 func TestChannelsForTeams_SameTeam(t *testing.T) {


### PR DESCRIPTION
Replicates the complete `prodChannelIds` map from the iOS repo (`main:Firepower/NHLTeams.swift`) into `channels.go`, filling in the 27 previously-empty teams so every NHL team resolves to a non-empty APNs broadcast channel. The 5 pre-existing IDs matched byte-for-byte, confirming iOS as the authoritative source and making this a verifiable copy rather than a guess. `channelForTeam` now never fails for a missing ID, so the scheduler's `TEAM_FILTER` becomes the sole guard on which teams send notifications. Adds `TestReplicateAll32ProdChannels` and `TestNoUnknownProdTeams` to enforce the map stays complete and typo-free, and updates three formatter tests that relied on the map having gaps to force the empties explicitly. Full suite passes (`go test ./...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)