### PR TITLE
fix: never send event:end on final push; client owns ending

### DIFF
--- a/watchgameupdates/internal/notification/liveactivity/formatter.go
+++ b/watchgameupdates/internal/notification/liveactivity/formatter.go
@@ -9,9 +9,8 @@ package liveactivity
 //     "payload": {
 //       "aps": {
 //         "timestamp":  1234567890,
-//         "event":      "update" | "end",
-//         "stale-date": 1234568890,       // update only: now + 90s
-//         "dismissal-date": 1234569490,   // end only: now + 10min
+//         "event":      "update",         // always — even on game-end, see below
+//         "stale-date": 1234568890,       // now + 90s, always — no special-casing
 //         "content-state": {
 //           "sport":       "nhl",
 //           "homeTeam":    "BOS",
@@ -41,10 +40,15 @@ import (
 	. "watchgameupdates/internal/notification"
 )
 
-const (
-	staleDateOffset = 90 * time.Second
-	dismissalOffset = 10 * time.Minute
-)
+// staleDateOffset applies to every push, including the final one. A game-end
+// push is not special at this layer: it is an ordinary content-state update
+// whose gameState happens to read "Final", exactly like any other moment's
+// gameState reads "14:32 left, 2nd period". The client alone decides what a
+// Final gameState means for the activity's lifecycle (see
+// LiveActivityManager.endIfFinal) — this backend never sends event:"end",
+// since a push with event:"end" is applied by the OS directly with no app
+// code in the loop, foreclosing the client's ability to decide anything.
+const staleDateOffset = 90 * time.Second
 
 // dispatchEnvelope is what FormatMessage returns and SendNotification parses.
 type dispatchEnvelope struct {
@@ -67,11 +71,10 @@ type contentState struct {
 }
 
 type apsEnvelope struct {
-	Timestamp     int64        `json:"timestamp"`
-	Event         string       `json:"event"`
-	StaleDate     *int64       `json:"stale-date,omitempty"`
-	DismissalDate *int64       `json:"dismissal-date,omitempty"`
-	ContentState  contentState `json:"content-state"`
+	Timestamp    int64        `json:"timestamp"`
+	Event        string       `json:"event"`
+	StaleDate    *int64       `json:"stale-date,omitempty"`
+	ContentState contentState `json:"content-state"`
 }
 
 type apnsPayload struct {
@@ -87,21 +90,13 @@ func BuildDispatchMessage(req NotificationRequest, useDevChannels bool) (string,
 	}
 
 	now := time.Now().Unix()
-	isEnded := strings.EqualFold(req.Data["gameState"], "final") ||
-		strings.EqualFold(req.Data["lastPlayType"], "game-end")
+	ts := now + int64(staleDateOffset.Seconds())
 
 	aps := apsEnvelope{
 		Timestamp:    now,
+		Event:        "update",
+		StaleDate:    &ts,
 		ContentState: cs,
-	}
-	if isEnded {
-		aps.Event = "end"
-		ts := now + int64(dismissalOffset.Seconds())
-		aps.DismissalDate = &ts
-	} else {
-		aps.Event = "update"
-		ts := now + int64(staleDateOffset.Seconds())
-		aps.StaleDate = &ts
 	}
 
 	payloadBytes, err := json.Marshal(apnsPayload{APS: aps})

--- a/watchgameupdates/internal/notification/liveactivity/formatter_test.go
+++ b/watchgameupdates/internal/notification/liveactivity/formatter_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"math"
 	"testing"
+	"time"
 
 	. "watchgameupdates/internal/notification"
 )
@@ -162,11 +163,13 @@ func TestBuildDispatchMessage_UnknownPlayType_EmptyEvent(t *testing.T) {
 
 func TestBuildDispatchMessage_GameEnded(t *testing.T) {
 	withChannels(t, map[string]string{"BOS": "chan-BOS", "NYR": "chan-NYR"}, false, func() {
+		before := time.Now().Unix()
 		req := baseReq()
 		req.Data["gameState"] = "Final"
 		req.Data["lastPlayType"] = "game-end"
 
 		msg, err := BuildDispatchMessage(req, false)
+		after := time.Now().Unix()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -177,14 +180,28 @@ func TestBuildDispatchMessage_GameEnded(t *testing.T) {
 		var payload apnsPayload
 		json.Unmarshal(env.Payload, &payload)
 
-		if payload.APS.Event != "end" {
-			t.Errorf("want event=end for game-end, got %s", payload.APS.Event)
+		// The backend never sends event:"end" — a push with event:"end" is
+		// applied by the OS directly with no app code in the loop, which
+		// would foreclose the iOS client's ability to decide when to end the
+		// activity. Ending it is the client's job (LiveActivityManager.endIfFinal).
+		if payload.APS.Event != "update" {
+			t.Errorf("want event=update for game-end (client owns ending), got %s", payload.APS.Event)
 		}
-		if payload.APS.DismissalDate == nil {
-			t.Error("want non-nil dismissal-date for game-end")
+
+		// A game-end push is NOT special at this layer: same stale-date offset
+		// as every other push. Asserting the exact value (not just non-nil)
+		// guards against reintroducing final-specific branching here — the
+		// only thing that makes this push "the end" is its content-state
+		// saying gameState="Final", which the client alone interprets.
+		if payload.APS.StaleDate == nil {
+			t.Fatal("want non-nil stale-date for game-end")
 		}
-		if payload.APS.StaleDate != nil {
-			t.Error("want nil stale-date for game-end")
+		wantMin := before + int64(staleDateOffset.Seconds())
+		wantMax := after + int64(staleDateOffset.Seconds())
+		got := *payload.APS.StaleDate
+		if got < wantMin || got > wantMax {
+			t.Errorf("stale-date = %d, want within [%d, %d] (now + %s) — game-end should use the same offset as any other push",
+				got, wantMin, wantMax, staleDateOffset)
 		}
 	})
 }


### PR DESCRIPTION
Companion to [FirepowerApp/ios#7](https://github.com/FirepowerApp/ios/pull/7). A push with `aps.event:"end"` is applied by the OS directly with no app code in the loop, so this backend could never actually hand the ending decision to the client no matter what `dismissal-date` it sent — every game-end push ended the Live Activity 10 minutes after the final whistle regardless of what the iOS client wanted to do.

Every push now sends `event:"update"`, including the final one — a game-end push isn't special at this layer, it's an ordinary content-state update whose `gameState` happens to read `"Final"`. `dismissalOffset`/`DismissalDate` are removed entirely.

The iOS client (`LiveActivityManager.endIfFinal`) now decides when a finished game's Live Activity ends, with its own 4-hour dismissal window. **Deploy after the iOS build ships** — per standard ordering, but also because old iOS clients degrade gracefully here (they'll just see an activity that lives longer than before, never worse than the current 10-minute cutoff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)