### PR TITLE
fix(notification): retry APNs push on HTTP/2 GOAWAY errors

### DIFF
--- a/watchgameupdates/internal/notification/liveactivity/apns_client.go
+++ b/watchgameupdates/internal/notification/liveactivity/apns_client.go
@@ -14,10 +14,12 @@ package liveactivity
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -119,6 +121,12 @@ func (e *retryableError) Error() string {
 }
 
 func isRetryable(err error) bool {
-	_, ok := err.(*retryableError)
-	return ok
+	var re *retryableError
+	if errors.As(err, &re) {
+		return true
+	}
+	if err != nil && strings.Contains(err.Error(), "GOAWAY") {
+		return true
+	}
+	return false
 }

--- a/watchgameupdates/internal/notification/liveactivity/notifier_test.go
+++ b/watchgameupdates/internal/notification/liveactivity/notifier_test.go
@@ -2,6 +2,7 @@ package liveactivity
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -149,5 +150,29 @@ func TestPushWithRetry_GoneIs200(t *testing.T) {
 	err := testNotifier(t, srv).pushWithRetry(context.Background(), "chan-1", []byte(`{}`))
 	if err != nil {
 		t.Errorf("expected 410 Gone to be treated as non-error, got: %v", err)
+	}
+}
+
+func TestIsRetryable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"GOAWAY", fmt.Errorf("http2: server sent GOAWAY and closed the connection"), true},
+		{"wrapped GOAWAY", fmt.Errorf("APNs push: %w", fmt.Errorf("GOAWAY frame received")), true},
+		{"retryable status", &retryableError{status: 429, body: "rate limited"}, true},
+		{"bad request", fmt.Errorf("APNs push unexpected status 400: bad request"), false},
+		{"context canceled", context.Canceled, false},
+		{"nil", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isRetryable(tt.err)
+			if got != tt.want {
+				t.Errorf("isRetryable(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- APNs periodically sends HTTP/2 GOAWAY frames to drain connections. When multiple game-end pushes fire in parallel through the same connection, all streams can fail simultaneously. Since game-end never reschedules, there is no future poll to re-deliver the Final state, leaving Live Activities stuck indefinitely.
- Expands `isRetryable` to classify GOAWAY transport errors as retryable so `pushWithRetry` opens a fresh connection on the next attempt. Also upgrades the `retryableError` check from a bare type assertion to `errors.As` for proper wrapped-error handling.
- Adds table-driven tests covering GOAWAY, wrapped GOAWAY, retryable HTTP status, non-retryable errors, context cancellation, and nil.

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] `TestIsRetryable` covers positive and negative cases for GOAWAY string matching
- [x] Verified via staging cluster logs that all 4 tracked games on 2026-08-03 hit GOAWAY errors on game-end pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)