### PR TITLE
fix(notification): apply shootout result to Live Activity score

### DIFF
--- a/watchgameupdates/internal/notification/liveactivity/notifier.go
+++ b/watchgameupdates/internal/notification/liveactivity/notifier.go
@@ -31,6 +31,8 @@ var requiredDataKeys = []string{
 	"awayTeamGoals",
 	"homeTeamExpectedGoals",
 	"awayTeamExpectedGoals",
+	"homeTeamShootOutGoals",
+	"awayTeamShootOutGoals",
 	"gameState",
 	"homeTeamAbbrev",
 	"awayTeamAbbrev",

--- a/watchgameupdates/internal/services/gameprocessor.go
+++ b/watchgameupdates/internal/services/gameprocessor.go
@@ -176,12 +176,12 @@ func AdjustScoreForShootout(gameData map[string]string) error {
 		return fmt.Errorf("invalid away goals: %w", err)
 	}
 
-	homeSOGoals, err := strconv.Atoi(gameData["homeTeamShootOutGoals"])
+	homeSOGoals, err := parseShootoutGoals(gameData["homeTeamShootOutGoals"])
 	if err != nil {
 		return fmt.Errorf("invalid home shootout goals: %w", err)
 	}
 
-	awaySOGoals, err := strconv.Atoi(gameData["awayTeamShootOutGoals"])
+	awaySOGoals, err := parseShootoutGoals(gameData["awayTeamShootOutGoals"])
 	if err != nil {
 		return fmt.Errorf("invalid away shootout goals: %w", err)
 	}
@@ -196,4 +196,14 @@ func AdjustScoreForShootout(gameData map[string]string) error {
 	gameData["awayTeamGoals"] = strconv.Itoa(awayScore)
 
 	return nil
+}
+
+// parseShootoutGoals treats a missing/empty shootout column as 0 goals rather
+// than an error, since a required-key mismatch upstream (or a non-shootout
+// game) can leave the field blank even when the CSV request otherwise succeeds.
+func parseShootoutGoals(value string) (int, error) {
+	if value == "" {
+		return 0, nil
+	}
+	return strconv.Atoi(value)
 }

--- a/watchgameupdates/internal/services/gameprocessor_test.go
+++ b/watchgameupdates/internal/services/gameprocessor_test.go
@@ -120,12 +120,17 @@ func TestAdjustScoreForShootout(t *testing.T) {
 			expectError:       true,
 		},
 		{
+			// A missing shootout column (e.g. a notifier that doesn't request it)
+			// is treated as 0 goals rather than an error, so the away team's
+			// shootout goal still breaks the tie.
 			name:              "MissingHomeShootoutGoals",
 			homeGoals:         "2",
 			awayGoals:         "2",
 			homeShootOutGoals: "",
 			awayShootOutGoals: "2",
-			expectError:       true,
+			expectedHomeGoals: "2",
+			expectedAwayGoals: "3",
+			expectError:       false,
 		},
 		{
 			name:              "MissingAwayShootoutGoals",
@@ -133,7 +138,19 @@ func TestAdjustScoreForShootout(t *testing.T) {
 			awayGoals:         "2",
 			homeShootOutGoals: "1",
 			awayShootOutGoals: "",
-			expectError:       true,
+			expectedHomeGoals: "3",
+			expectedAwayGoals: "2",
+			expectError:       false,
+		},
+		{
+			name:              "MissingBothShootoutGoals",
+			homeGoals:         "2",
+			awayGoals:         "2",
+			homeShootOutGoals: "",
+			awayShootOutGoals: "",
+			expectedHomeGoals: "2",
+			expectedAwayGoals: "2",
+			expectError:       false,
 		},
 	}
 


### PR DESCRIPTION
## Summary
- `LiveActivityNotifier` never declared `homeTeamShootOutGoals` / `awayTeamShootOutGoals` in its required data keys, so those CSV columns were never fetched from MoneyPuck for the Live Activity path (the Discord notifier fetches them fine, but Discord isn't registered in prod/staging).
- `AdjustScoreForShootout` then failed to parse the missing value (`strconv.Atoi("")`), logged `Failed to adjust score for shootout`, and skipped the adjustment — so any real game decided in a shootout would be broadcast to Live Activities as a regulation tie.
- Confirmed via cluster logs + a direct query of the staging MoneyPuck emulator: two staging games (WSH-NJD, CBJ-NYR) ended in OT ties, both actually had valid shootout data (`1,2` and `1,2` respectively) that the backend simply never requested.

## Changes
- Add `homeTeamShootOutGoals` / `awayTeamShootOutGoals` to `LiveActivityNotifier.requiredDataKeys`.
- Harden `AdjustScoreForShootout` to treat a missing/empty shootout column as 0 goals rather than erroring out, so a partial-data scenario degrades gracefully instead of silently no-opping the whole adjustment.
- Update/add unit tests for the missing-column cases.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (all packages pass)
- [x] `go vet ./...`
- [ ] Verify against staging emulator that a shootout game now resolves correctly in the pushed Live Activity payload